### PR TITLE
✨ Add CSV export and list filtering while fixing Gemini and subtask export issues

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -143,7 +143,7 @@ This project leverages MCP (Model Context Protocol) tools for enhanced developme
 
 ## Developer workflow
 
-- Requirements live in `requirements.txt`; core deps are `requests`, `rich`, with optional `onepassword-sdk` and `google-generativeai`—guard imports accordingly.
+- Requirements live in `requirements.txt`; core deps are `requests`, `rich`, with optional `onepassword-sdk` and `google-genai`—guard imports accordingly.
 - Typical runs: `python main.py` (Markdown export, workspace `KMS`, space `Kikkoman`), or override with `--output-format {Markdown|HTML}`, `--interactive`, `--include-completed`, `--date-filter {AllOpen|ThisWeek|LastWeek}`, and `--ai-summary/--gemini-api-key`.
 - The extractor writes to `output/` using the timestamped path from `config.default_output_path()`; exporters adjust the extension per selected format.
 - Version bumps: update `version.py` (`__version__` and related metadata), refresh the README version badge URL, and add a new entry in `docs/CHANGELOG.md` summarizing changes since the previous release.

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ Each prompt provides clear options and defaults, making it easy to configure the
 
 ## 🔧 Development workflow
 
-- Install deps via `pip install -r requirements.txt`; optional features require `onepassword-sdk` and `google-generativeai` which are already listed.
+- Install deps via `pip install -r requirements.txt`; optional features require `onepassword-sdk` and `google-genai` which are already listed.
 - Run the extractor with `python main.py` (defaults: workspace `KMS`, space `Kikkoman`, Markdown export). Override with `--output-format`, `--interactive`, `--include-completed`, `--date-filter`, `--ai-summary`, and `--gemini-api-key`.
 - Authentication falls back in this order: CLI flag → env var `CLICKUP_API_KEY` → 1Password SDK (requires `OP_SERVICE_ACCOUNT_TOKEN`) → `op read` CLI → manual prompt.
 - Logging comes from `logger_config.setup_logging`; pass `use_rich=False` for plain output or a `log_file` path to persist logs.
@@ -318,7 +318,7 @@ _reset_daily_quota_state()
 ### Optional Dependencies
 
 - `onepassword-sdk>=0.3.1` - Secure credential management
-- `google-generativeai>=0.8.0` - AI-powered task summaries
+- `google-genai>=1.0.0` - AI-powered task summaries
 
 ## 🐛 Troubleshooting
 

--- a/ai_summary.py
+++ b/ai_summary.py
@@ -41,11 +41,38 @@ SummaryResult: TypeAlias = str | None
 _api_available = True
 _last_error_message = ""
 
-# Google GenAI SDK imports
+# Google GenAI SDK imports (google.genai)
 try:
-    from google.generativeai.client import configure  # type: ignore
-    from google.generativeai.generative_models import GenerativeModel  # type: ignore
-    from google.generativeai import types  # type: ignore
+    from google import genai as _genai  # type: ignore
+    from google.genai import types as _genai_types  # type: ignore
+
+    _genai_client = None
+
+    def configure(api_key: str) -> None:
+        """Configure a shared Google GenAI client."""
+
+        global _genai_client
+        _genai_client = _genai.Client(api_key=api_key)
+
+    class GenerativeModel:
+        """Compatibility wrapper matching legacy GenerativeModel usage."""
+
+        def __init__(self, model_name: str) -> None:
+            self.model_name = model_name
+
+        def generate_content(self, prompt: str, generation_config=None):
+            if _genai_client is None:
+                raise RuntimeError("Google GenAI client is not configured")
+            return _genai_client.models.generate_content(
+                model=self.model_name,
+                contents=prompt,
+                config=generation_config,
+            )
+
+    class _TypesNamespace:
+        GenerationConfig = _genai_types.GenerateContentConfig
+
+    types = _TypesNamespace()
 except ImportError:
     configure = None
     GenerativeModel = None
@@ -262,11 +289,11 @@ def get_ai_summary(
     if GenerativeModel is None or configure is None or types is None:
         if RICH_AVAILABLE and _console:
             _console.print(
-                "[yellow]Warning: Google GenAI SDK not available - install with: pip install google-generativeai[/yellow]"
+                "[yellow]Warning: Google GenAI SDK not available - install with: pip install google-genai[/yellow]"
             )
         else:
             print(
-                "Warning: Google GenAI SDK not available - install with: pip install google-generativeai"
+                "Warning: Google GenAI SDK not available - install with: pip install google-genai"
             )
         return field_block
 

--- a/config.py
+++ b/config.py
@@ -272,6 +272,7 @@ class ClickUpConfig:
         api_key: ClickUp API key for authentication
         workspace_name: Name of the ClickUp workspace to extract from
         space_name: Name of the ClickUp space within the workspace
+        list_name: Optional ClickUp list name to extract from within the selected space
         team_id: ClickUp Team/Workspace ID (optional, used if /team endpoint fails)
         output_path: File path for exported task data
         include_completed: Whether to include completed/archived tasks
@@ -294,6 +295,7 @@ class ClickUpConfig:
     api_key: str
     workspace_name: str = "KMS"
     space_name: str = "Kikkoman"
+    list_name: str | None = None
     team_id: str = "9014534294"
     output_path: str = field(default_factory=default_output_path)
     include_completed: bool = False

--- a/config.py
+++ b/config.py
@@ -58,6 +58,7 @@ CLICKUP_AI_SUMMARY_FIELD_ID = "d7426f47-27f0-494b-b3a2-7d254132ee1a"
 class OutputFormat(Enum):
     """Enumeration of supported output formats."""
 
+    CSV = "CSV"
     HTML = "HTML"
     MARKDOWN = "Markdown"
 

--- a/eta_calculator.py
+++ b/eta_calculator.py
@@ -22,11 +22,38 @@ except ImportError:
     _console = None
     RICH_AVAILABLE = False
 
-# Google GenAI SDK imports
+# Google GenAI SDK imports (google.genai)
 try:
-    from google.generativeai.client import configure  # type: ignore
-    from google.generativeai.generative_models import GenerativeModel  # type: ignore
-    from google.generativeai import types  # type: ignore
+    from google import genai as _genai  # type: ignore
+    from google.genai import types as _genai_types  # type: ignore
+
+    _genai_client = None
+
+    def configure(api_key: str) -> None:
+        """Configure a shared Google GenAI client."""
+
+        global _genai_client
+        _genai_client = _genai.Client(api_key=api_key)
+
+    class GenerativeModel:
+        """Compatibility wrapper matching legacy GenerativeModel usage."""
+
+        def __init__(self, model_name: str) -> None:
+            self.model_name = model_name
+
+        def generate_content(self, prompt: str, generation_config=None):
+            if _genai_client is None:
+                raise RuntimeError("Google GenAI client is not configured")
+            return _genai_client.models.generate_content(
+                model=self.model_name,
+                contents=prompt,
+                config=generation_config,
+            )
+
+    class _TypesNamespace:
+        GenerationConfig = _genai_types.GenerateContentConfig
+
+    types = _TypesNamespace()
 except ImportError:
     configure = None
     GenerativeModel = None

--- a/extractor.py
+++ b/extractor.py
@@ -1183,9 +1183,6 @@ h1{color:#2c5aa0;}
 
             prefix = f"- **{label}:** "
             safe_value = value if value else "(not provided)"
-            # Keep generated output concise and lint-safe even for very long task notes.
-            if len(safe_value) > 240:
-                safe_value = safe_value[:237].rstrip() + "..."
             return textwrap.fill(
                 prefix + safe_value,
                 width=79,

--- a/extractor.py
+++ b/extractor.py
@@ -12,6 +12,7 @@ Contains:
 import os
 import sys
 import html
+import csv
 from datetime import datetime, timezone
 from typing import Callable, TypeAlias
 from contextlib import contextmanager
@@ -1057,6 +1058,28 @@ class ClickUpTaskExtractor:
             TextColumn("[progress.description]{task.description}"),
             console=console,
         ) as progress:
+            # CSV Export
+            if self.config.output_format == OutputFormat.CSV:
+                csv_task = progress.add_task("📊 Generating CSV...", total=None)
+                csv_path = output_dir / f"{base_filename}.csv"
+                export_fields = get_export_fields()
+
+                with export_file(str(csv_path), "w") as f:
+                    writer = csv.DictWriter(f, fieldnames=export_fields)
+                    writer.writeheader()
+                    for task in tasks:
+                        writer.writerow(
+                            {
+                                field: getattr(task, field) or ""
+                                for field in export_fields
+                            }
+                        )
+
+                progress.remove_task(csv_task)
+                console.print(
+                    f"✅ [green]CSV exported:[/green] [bold]{csv_path}[/bold]"
+                )
+
             # HTML Export
             if self.config.output_format == OutputFormat.HTML:
                 html_task = progress.add_task("🌐 Generating HTML...", total=None)

--- a/extractor.py
+++ b/extractor.py
@@ -314,6 +314,25 @@ class ClickUpTaskExtractor:
                     "lists"
                 ]
                 lists.extend(space_lists)
+
+                if self.config.list_name:
+                    target_list_name = self.config.list_name.strip().lower()
+                    lists = [
+                        list_item
+                        for list_item in lists
+                        if list_item.get("name", "").strip().lower() == target_list_name
+                    ]
+
+                    if not lists:
+                        console.print(
+                            Panel(
+                                f"[red]List '{self.config.list_name}' not found in space '{self.config.space_name}'.[/red]\n"
+                                f"[dim]Check the list name and try again.[/dim]",
+                                title="❌ List Error",
+                                style="red",
+                            )
+                        )
+                        return
                 progress.remove_task(task)
 
                 console.print(
@@ -341,7 +360,7 @@ class ClickUpTaskExtractor:
                         progress.remove_task(current_list_task)
 
                     tasks_resp = self.api.get(
-                        f"/list/{list_item['id']}/task?archived={str(self.config.include_completed).lower()}"
+                        f"/list/{list_item['id']}/task?archived={str(self.config.include_completed).lower()}&subtasks=true"
                     )
                     tasks = tasks_resp.get("tasks", [])
 

--- a/main.py
+++ b/main.py
@@ -46,6 +46,22 @@ from logger_config import setup_logging
 from mappers import get_choice_input, get_yes_no_input
 from version import __description__, __version__
 
+
+def _configure_stdio_encoding() -> None:
+    """Use UTF-8 for stdio when supported to avoid Windows cp1252 encode failures."""
+
+    for stream in (sys.stdout, sys.stderr):
+        reconfigure = getattr(stream, "reconfigure", None)
+        if callable(reconfigure):
+            try:
+                reconfigure(encoding="utf-8", errors="replace")
+            except (ValueError, OSError):
+                # Some stream wrappers do not allow reconfiguration.
+                continue
+
+
+_configure_stdio_encoding()
+
 # Initialize Rich console with proper encoding for cross-platform compatibility
 # This ensures proper rendering on Windows, macOS, and Linux
 console = Console(force_terminal=None, legacy_windows=False)

--- a/main.py
+++ b/main.py
@@ -131,6 +131,9 @@ def main():
     parser.add_argument("--workspace", type=str, help="Workspace name (default: KMS)")
     parser.add_argument("--space", type=str, help="Space name (default: Kikkoman)")
     parser.add_argument(
+        "--list", type=str, help="Optional list name to extract from within the space"
+    )
+    parser.add_argument(
         "--output", type=str, help="Output file path (default: auto-generated)"
     )
     parser.add_argument(
@@ -401,6 +404,7 @@ def main():
         api_key=api_key,
         workspace_name=args.workspace or "KMS",
         space_name=args.space or "Kikkoman",
+        list_name=args.list,
         output_path=args.output
         or f"output/WeeklyTaskList_{format_datetime(datetime.now(), TIMESTAMP_FORMAT)}.md",
         include_completed=args.include_completed,
@@ -422,6 +426,8 @@ def main():
 
     config_table.add_row("Workspace", config.workspace_name)
     config_table.add_row("Space", config.space_name)
+    if config.list_name:
+        config_table.add_row("List", config.list_name)
     config_table.add_row("Output Format", config.output_format.value)
     config_table.add_row("Date Filter", config.date_filter.value)
     config_table.add_row(

--- a/main.py
+++ b/main.py
@@ -171,8 +171,8 @@ def main():
     parser.add_argument(
         "--output-format",
         type=str,
-        choices=["HTML", "Markdown"],
-        help="Output format: HTML or Markdown - default: Markdown",
+        choices=["CSV", "HTML", "Markdown"],
+        help="Output format: CSV, HTML, or Markdown - default: Markdown",
     )
     parser.add_argument(
         "--interactive", action="store_true", help="Enable interactive task selection"
@@ -351,12 +351,13 @@ def main():
     if not args.output_format:
         console.print("\n[bold blue]📄 Output Format[/bold blue]")
         console.print("Choose the format for your exported task list:")
+        console.print("  • [cyan]CSV[/cyan] - Spreadsheet-friendly table output")
         console.print("  • [cyan]HTML[/cyan] - Rich formatted web page with styling")
         console.print("  • [cyan]Markdown[/cyan] - Lightweight markup format")
 
-        format_choices = ["Markdown", "HTML"]
+        format_choices = ["Markdown", "HTML", "CSV"]
         selected_format = get_choice_input(
-            "Enter your choice (1-2) or format name [default: Markdown]: ",
+            "Enter your choice (1-3) or format name [default: Markdown]: ",
             format_choices,
             default_index=0,
         )
@@ -384,6 +385,7 @@ def main():
         except ValueError:
             # Fallback for old string values
             output_format_map = {
+                "CSV": OutputFormat.CSV,
                 "HTML": OutputFormat.HTML,
                 "Markdown": OutputFormat.MARKDOWN,
             }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 requests>=2.25.0
 onepassword-sdk>=0.3.1
-google-generativeai>=0.8.0  # Google Gemini API (legacy but stable)
+google-genai>=1.0.0  # Google Gemini API SDK
 rich>=14.0.0
 

--- a/tests/test_extractor.py
+++ b/tests/test_extractor.py
@@ -1,5 +1,6 @@
 import tempfile
 import unittest
+import csv
 from datetime import datetime
 from pathlib import Path
 from typing import Any, cast
@@ -285,6 +286,27 @@ class ExportBehaviourTests(unittest.TestCase):
             self.assertTrue(html_path.exists())
             html_content = html_path.read_text(encoding="utf-8")
             self.assertIn("Weekly Task List", html_content)
+
+    def test_csv_export_creates_file(self) -> None:
+        with tempfile.TemporaryDirectory() as tmpdir:
+            output_path = Path(tmpdir) / "report.md"
+            config = ClickUpConfig(
+                api_key="dummy",
+                output_path=str(output_path),
+                output_format=OutputFormat.CSV,
+            )
+            extractor = ClickUpTaskExtractor(config, DummyAPIClient({}))
+
+            extractor.export([self.task])
+
+            csv_path = Path("output") / "report.csv"
+            self.assertTrue(csv_path.exists())
+            with csv_path.open(encoding="utf-8", newline="") as handle:
+                rows = list(csv.DictReader(handle))
+
+            self.assertEqual(len(rows), 1)
+            self.assertEqual(rows[0]["Task"], "Task A")
+            self.assertEqual(rows[0]["Notes"], "Sample notes")
 
 
 class FetchProcessTasksTests(unittest.TestCase):

--- a/tests/test_extractor.py
+++ b/tests/test_extractor.py
@@ -327,7 +327,7 @@ class FetchProcessTasksTests(unittest.TestCase):
             "/space/space1/list?archived=false": {
                 "lists": [{"id": "list1", "name": "Support"}]
             },
-            "/list/list1/task?archived=false": {
+            "/list/list1/task?archived=false&subtasks=true": {
                 "tasks": [
                     {
                         "id": "task1",
@@ -390,6 +390,138 @@ class FetchProcessTasksTests(unittest.TestCase):
             self.assertEqual(task_record.Priority, "High")
             self.assertEqual(task_record.Status, "In Progress")
             self.assertIn("Subject: Printer outage", task_record.Notes)
+
+    def test_fetch_and_process_tasks_filters_to_requested_list(self) -> None:
+        timestamp_ms = int(datetime(2025, 10, 7, 12, 0, 0).timestamp() * 1000)
+
+        responses: dict[str, Any] = {
+            "/team": {"teams": [{"id": "team1", "name": "KMS"}]},
+            "/team/team1/space": {"spaces": [{"id": "space1", "name": "Kikkoman"}]},
+            "/space/space1/folder": {"folders": []},
+            "/space/space1/list?archived=false": {
+                "lists": [
+                    {"id": "list1", "name": "KFI Jefferson"},
+                    {"id": "list2", "name": "Other List"},
+                ]
+            },
+            "/list/list1/task?archived=false&subtasks=true": {
+                "tasks": [
+                    {
+                        "id": "task1",
+                        "name": "Jefferson Task",
+                        "archived": False,
+                        "status": {"status": "open"},
+                        "date_created": str(timestamp_ms),
+                    }
+                ]
+            },
+            "/list/list1": {"custom_fields": []},
+            "/task/task1": {
+                "name": "Jefferson Task",
+                "priority": {"priority": 3},
+                "status": {"status": "In Progress"},
+                "description": "Jefferson details",
+                "custom_fields": [],
+            },
+        }
+
+        class RecordingExtractor(ClickUpTaskExtractor):
+            def __init__(self, *args, **kwargs) -> None:
+                super().__init__(*args, **kwargs)
+                self.export_calls: list[list[TaskRecord]] = []
+
+            def export(self, tasks: list[TaskRecord]) -> None:  # type: ignore[override]
+                self.export_calls.append(tasks)
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config = ClickUpConfig(
+                api_key="dummy",
+                output_path=str(Path(tmpdir) / "out.md"),
+                team_id="team1",
+                list_name="KFI Jefferson",
+            )
+            api_client = DummyAPIClient(responses)
+            extractor = RecordingExtractor(config, api_client)
+
+            extractor._fetch_and_process_tasks()
+
+            self.assertEqual(len(extractor.export_calls), 1)
+            exported_tasks = extractor.export_calls[0]
+            self.assertEqual(len(exported_tasks), 1)
+            self.assertEqual(exported_tasks[0].Task, "Jefferson Task")
+
+    def test_fetch_and_process_tasks_includes_subtasks(self) -> None:
+        timestamp_ms = int(datetime(2025, 10, 7, 12, 0, 0).timestamp() * 1000)
+
+        responses: dict[str, Any] = {
+            "/team": {"teams": [{"id": "team1", "name": "KMS"}]},
+            "/team/team1/space": {"spaces": [{"id": "space1", "name": "Kikkoman"}]},
+            "/space/space1/folder": {"folders": []},
+            "/space/space1/list?archived=false": {
+                "lists": [{"id": "list1", "name": "Support"}]
+            },
+            "/list/list1/task?archived=false&subtasks=true": {
+                "tasks": [
+                    {
+                        "id": "task1",
+                        "name": "Parent Task",
+                        "archived": False,
+                        "status": {"status": "open"},
+                        "date_created": str(timestamp_ms),
+                    },
+                    {
+                        "id": "task2",
+                        "name": "Child Task",
+                        "archived": False,
+                        "status": {"status": "open"},
+                        "date_created": str(timestamp_ms),
+                        "parent": "task1",
+                    },
+                ]
+            },
+            "/list/list1": {"custom_fields": []},
+            "/task/task1": {
+                "name": "Parent Task",
+                "priority": {"priority": 3},
+                "status": {"status": "In Progress"},
+                "description": "Parent details",
+                "custom_fields": [],
+            },
+            "/task/task2": {
+                "name": "Child Task",
+                "priority": {"priority": 2},
+                "status": {"status": "Open"},
+                "description": "Subtask details",
+                "parent": "task1",
+                "custom_fields": [],
+            },
+        }
+
+        class RecordingExtractor(ClickUpTaskExtractor):
+            def __init__(self, *args, **kwargs) -> None:
+                super().__init__(*args, **kwargs)
+                self.export_calls: list[list[TaskRecord]] = []
+
+            def export(self, tasks: list[TaskRecord]) -> None:  # type: ignore[override]
+                self.export_calls.append(tasks)
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config = ClickUpConfig(
+                api_key="dummy",
+                output_path=str(Path(tmpdir) / "out.md"),
+                team_id="team1",
+            )
+            api_client = DummyAPIClient(responses)
+            extractor = RecordingExtractor(config, api_client)
+
+            extractor._fetch_and_process_tasks()
+
+            self.assertEqual(len(extractor.export_calls), 1)
+            exported_tasks = extractor.export_calls[0]
+            self.assertEqual(len(exported_tasks), 2)
+            self.assertEqual(
+                [task.Task for task in exported_tasks], ["Parent Task", "Child Task"]
+            )
 
 
 class TaskExportSortingTests(unittest.TestCase):

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -104,7 +104,7 @@ class MainEntrypointTests(unittest.TestCase):
                 main_module, "get_yes_no_input", return_value=False
             ) as mock_yes_no,
             patch.object(
-                main_module, "get_choice_input", return_value="Markdown"
+                main_module, "get_choice_input", return_value="CSV"
             ) as mock_choice_input,
             patch.object(main_module, "load_secret_with_fallback") as mock_load_secret,
             patch.object(main_module, "ClickUpTaskExtractor") as mock_extractor_cls,
@@ -129,11 +129,12 @@ class MainEntrypointTests(unittest.TestCase):
         call_args = mock_choice_input.call_args
         self.assertIn("Markdown", call_args.args[1])
         self.assertIn("HTML", call_args.args[1])
-        self.assertEqual(len(call_args.args[1]), 2)
+        self.assertIn("CSV", call_args.args[1])
+        self.assertEqual(len(call_args.args[1]), 3)
 
         # Verify config was set with the selected format
         config_arg = mock_extractor_cls.call_args.args[0]
-        self.assertEqual(config_arg.output_format, OutputFormat.MARKDOWN)
+        self.assertEqual(config_arg.output_format, OutputFormat.CSV)
 
 
 if __name__ == "__main__":  # pragma: no cover - manual execution safeguard

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -50,6 +50,8 @@ class MainEntrypointTests(unittest.TestCase):
                 "Acme Workspace",
                 "--space",
                 "Ops",
+                "--list",
+                "KFI Jefferson",
                 "--output",
                 "output/custom.md",
                 "--include-completed",
@@ -77,6 +79,7 @@ class MainEntrypointTests(unittest.TestCase):
         self.assertEqual(config_arg.api_key, "test-key")
         self.assertEqual(config_arg.workspace_name, "Acme Workspace")
         self.assertEqual(config_arg.space_name, "Ops")
+        self.assertEqual(config_arg.list_name, "KFI Jefferson")
         self.assertEqual(config_arg.output_path, "output/custom.md")
         self.assertTrue(config_arg.include_completed)
         self.assertEqual(config_arg.date_filter, DateFilter.LAST_WEEK)


### PR DESCRIPTION
### What does this PR do?

- Migrates Gemini integrations from deprecated `google.generativeai` to `google.genai` and updates dependencies/docs accordingly.
- Fixes export/runtime regressions by preserving full markdown task content and configuring UTF-8 stdio for redirected Windows runs.
- Ensures ClickUp subtasks are included in exports by requesting `subtasks=true` on list task fetches.
- Adds optional `--list` filtering so exports can target a single ClickUp list within a space.
- Adds CSV export support alongside the existing Markdown and HTML outputs.
- Expands focused test coverage for CLI format selection, single-list filtering, subtask export, and CSV generation.

### Why are we doing this?

- The legacy Gemini SDK is deprecated and needed to be replaced before it caused further breakage.
- Exported markdown content was being truncated, and some Windows runs could fail with Unicode encoding errors.
- Subtasks were missing from exports, which blocked validation against real ClickUp lists.
- Single-list export makes it easier to test and generate targeted reports.
- CSV output provides a spreadsheet-friendly format without requiring Excel-specific dependencies.

### How should this be tested?

- Run: `python main.py --help` and confirm no `google.generativeai` deprecation warning appears.
- Run: `python -m pytest tests/test_ai_summary.py tests/test_ai_summary_success.py tests/test_eta_calculator.py -q`.
- Run: `python -m pytest tests/test_main.py tests/test_extractor.py -q`.
- Run a targeted export such as `python main.py --workspace KMS --space Kikkoman --list "KFI Jefferson" --output-format CSV` and verify the export completes with subtasks included when present.
- Run a markdown export and verify long Notes values are preserved without forced truncation.

### Any deployment notes?

- Install updated dependencies from `requirements.txt`, which now uses `google-genai`.
- Existing environments can optionally remove `google-generativeai` if it is still installed.
- No database or migration steps are required for the new list filter or CSV export support.
