### PR TITLE
fix: disable show_locals in Rich traceback (#105)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -29,6 +29,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Clarified the supported account selection flow for DesktopAuth and service-account auth.
 - Enabled executable workflows with `OP_ENVIRONMENT_ID` by reading Environment variables through 1Password CLI.
 
+### Security
+
+- Disabled `show_locals` in the Rich traceback handler (`logger_config.py`) so unhandled exceptions no longer render local variable contents — a stack frame could hold an API key or other secret, which `show_locals=True` would have printed to the console/logs (#105).
+
 ## [1.04] - 2026-04-07
 
 ### Fixed

--- a/logger_config.py
+++ b/logger_config.py
@@ -21,8 +21,11 @@ try:
 
     RICH_AVAILABLE = True
 
-    # Install rich tracebacks for beautiful error displays
-    install(show_locals=True, suppress=["logging"])
+    # Install rich tracebacks for beautiful error displays.
+    # show_locals is kept False so unhandled exceptions never render the
+    # contents of local variables — a stack frame may hold an API key or
+    # other secret, and show_locals=True would leak it to the console/logs.
+    install(show_locals=False, suppress=["logging"])
 except ImportError:
     RICH_AVAILABLE = False
     RichHandler = None


### PR DESCRIPTION
Fixes #105

## What changed
`logger_config.py` installed Rich's traceback handler with `show_locals=True`. When an unhandled exception propagates, Rich renders the local variables of every stack frame. Frames in the authentication / API-request path hold the ClickUp or Gemini API key, so any crash would print those tokens to the console and to file logs.

Changed the call to `install(show_locals=False, suppress=["logging"])`. Tracebacks still show the exception type, message, and source frames — only the per-frame locals dump (the leak vector) is removed.

## Testing / self-review
- `tests/test_logger_config.py` — 23 passed in isolation.
- `python -m py_compile logger_config.py` — clean.
- `grep -rn show_locals` confirms the only remaining references are the new code and its explanatory comment.
- Re-read the diff: scoped to the single `install(...)` call plus a `### Security` CHANGELOG entry. No behavior change beyond suppressing locals in tracebacks.