### PR TITLE
fix: correct invalid GEMINI_MODEL identifier (#109)

### DIFF
--- a/ai_summary.py
+++ b/ai_summary.py
@@ -4,16 +4,26 @@
 AI Integration Module for ClickUp Task Extractor
 
 Contains:
-- AI summary generation using Google Gemini Flash-Latest API
+- AI summary generation using the Google Gemini API
 - Rate limiting and retry logic
 - Progress bar functionality for wait times
 """
 
+import os
 import time
 from typing import Callable, Mapping, Sequence, TypeAlias
 
-# Use Gemini Flash-Lite-Latest for AI summaries (paid tier)
-GEMINI_MODEL = "gemini-flash-lite-latest"
+# Gemini model used for AI summaries.
+#
+# Must be a published Google model id (see
+# https://ai.google.dev/gemini-api/docs/models). The previous value
+# "gemini-flash-lite-latest" was not a real model id and returned an
+# invalid-model error at runtime. "gemini-2.5-flash-lite" is the GA,
+# cost-efficient Flash-Lite tier documented in the README.
+#
+# Overridable via the GEMINI_MODEL environment variable so the model can be
+# bumped without a code change.
+GEMINI_MODEL = os.environ.get("GEMINI_MODEL", "gemini-2.5-flash-lite")
 
 # Rich console imports - create singleton instance with proper encoding for Windows
 try:

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Removed the broken legacy vault-only fallback for Environment-based authentication.
 - Clarified the supported account selection flow for DesktopAuth and service-account auth.
 - Enabled executable workflows with `OP_ENVIRONMENT_ID` by reading Environment variables through 1Password CLI.
+- Corrected the Gemini model identifier from the invalid `gemini-flash-lite-latest` to the published `gemini-2.5-flash-lite` in `ai_summary.py` and `eta_calculator.py`; the value is now overridable via the `GEMINI_MODEL` environment variable. Added smoke tests that reject malformed model ids and the known-bad value (#109).
 
 ### Security
 

--- a/eta_calculator.py
+++ b/eta_calculator.py
@@ -9,6 +9,7 @@ Contains:
 - Fallback mechanisms for when AI is unavailable
 """
 
+import os
 from datetime import datetime, timedelta
 from typing import TypeAlias
 
@@ -62,8 +63,11 @@ except ImportError:
 # Type aliases
 ETAResult: TypeAlias = str
 
-# AI Model configuration
-GEMINI_MODEL = "gemini-flash-lite-latest"
+# AI Model configuration.
+# Must be a published Google model id. The previous "gemini-flash-lite-latest"
+# was not a real model id; "gemini-2.5-flash-lite" is the GA Flash-Lite tier.
+# Overridable via the GEMINI_MODEL environment variable.
+GEMINI_MODEL = os.environ.get("GEMINI_MODEL", "gemini-2.5-flash-lite")
 
 # Priority-based default ETA offsets (in days)
 PRIORITY_ETA_DAYS = {

--- a/tests/test_ai_summary.py
+++ b/tests/test_ai_summary.py
@@ -1,6 +1,35 @@
+import re
 import unittest
 
+import ai_summary
+import eta_calculator
 from ai_summary import _normalize_field_entries, get_ai_summary
+
+
+# Published Google Gemini model ids follow this shape, e.g.
+# "gemini-2.5-flash-lite", "gemini-2.5-pro", "gemini-2.0-flash".
+# See https://ai.google.dev/gemini-api/docs/models
+_VALID_GEMINI_MODEL_RE = re.compile(r"^gemini-\d+(?:\.\d+)?-[a-z0-9-]+$")
+
+# Known-invalid id that previously shipped and returned an invalid-model error
+# at runtime. Guarding against it explicitly prevents a regression.
+_KNOWN_BAD_MODEL = "gemini-flash-lite-latest"
+
+
+class GeminiModelSmokeTests(unittest.TestCase):
+    """Catch model-name regressions without making a live API call (issue #109)."""
+
+    def test_ai_summary_model_id_is_well_formed(self) -> None:
+        self.assertNotEqual(ai_summary.GEMINI_MODEL, _KNOWN_BAD_MODEL)
+        self.assertRegex(ai_summary.GEMINI_MODEL, _VALID_GEMINI_MODEL_RE)
+
+    def test_eta_calculator_model_id_is_well_formed(self) -> None:
+        self.assertNotEqual(eta_calculator.GEMINI_MODEL, _KNOWN_BAD_MODEL)
+        self.assertRegex(eta_calculator.GEMINI_MODEL, _VALID_GEMINI_MODEL_RE)
+
+    def test_model_ids_match_across_modules(self) -> None:
+        # Both modules drive the same Gemini integration; their defaults must agree.
+        self.assertEqual(ai_summary.GEMINI_MODEL, eta_calculator.GEMINI_MODEL)
 
 
 class NormalizeFieldEntriesTests(unittest.TestCase):

--- a/tests/test_ai_summary_success.py
+++ b/tests/test_ai_summary_success.py
@@ -402,7 +402,9 @@ class TestRateLimitingAndRetry(unittest.TestCase):
     @patch('ai_summary.GenerativeModel')
     @patch('ai_summary.configure')
     def test_uses_correct_model(self, mock_configure, mock_model_class, mock_types):
-        """Test uses correct Gemini model (gemini-flash-lite-latest)."""
+        """Test uses the configured Gemini model (ai_summary.GEMINI_MODEL)."""
+        import ai_summary
+
         mock_model = Mock()
         mock_response = Mock()
         mock_response.text = 'Summary'
@@ -412,8 +414,8 @@ class TestRateLimitingAndRetry(unittest.TestCase):
         field_entries = [('Name', 'Task')]
         get_ai_summary('Task', field_entries, 'api_key')
 
-        # Verify GenerativeModel was called with the correct model
-        mock_model_class.assert_called_once_with('gemini-flash-lite-latest')
+        # Verify GenerativeModel was called with the module's configured model id.
+        mock_model_class.assert_called_once_with(ai_summary.GEMINI_MODEL)
 
     @patch('ai_summary.types')
     @patch('ai_summary.GenerativeModel')


### PR DESCRIPTION
Fixes #109

## What changed
`ai_summary.py` and `eta_calculator.py` both set `GEMINI_MODEL = "gemini-flash-lite-latest"`, which is not a published Google model id and returns an invalid-model error from the Gemini API at runtime. The README/CLAUDE.md already document the intended Tier 1 model as the valid `gemini-2.5-flash-lite`.

- Both modules now use `os.environ.get("GEMINI_MODEL", "gemini-2.5-flash-lite")` — valid by default, overridable via env var without a code change.
- Added `import os` to `eta_calculator.py`; fixed the stale "Flash-Latest API" docstring in `ai_summary.py`.
- Updated `test_uses_correct_model` to assert against `ai_summary.GEMINI_MODEL` instead of the hardcoded bad literal.
- Added `GeminiModelSmokeTests` (in `tests/test_ai_summary.py`) that reject the known-bad id, require a published-id shape, and confirm both modules agree — catching model-name regressions without a live API call.

## Testing / self-review
- `pytest tests/test_ai_summary.py tests/test_ai_summary_success.py tests/test_eta_calculator.py` — 44 passed.
- `py_compile` clean on all changed files.
- Verified `gemini-2.5-flash-lite` is the current GA model id via Google's docs.
- Fixed the second copy in `eta_calculator.py` (not named in the issue but the identical bug) so the codebase stays consistent.