### PR TITLE
fix: guard module-level side effects behind __main__ (#107)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Clarified the supported account selection flow for DesktopAuth and service-account auth.
 - Enabled executable workflows with `OP_ENVIRONMENT_ID` by reading Environment variables through 1Password CLI.
 - Corrected the Gemini model identifier from the invalid `gemini-flash-lite-latest` to the published `gemini-2.5-flash-lite` in `ai_summary.py` and `eta_calculator.py`; the value is now overridable via the `GEMINI_MODEL` environment variable. Added smoke tests that reject malformed model ids and the known-bad value (#109).
+- Guarded module-level side effects in `main.py` and `kfj_task_extractor.py` behind `if __name__ == "__main__"`. The virtualenv re-exec, UTF-8 stdio reconfiguration, and `setup_logging()` no longer run at import time, so the modules can be imported by tests and tooling without triggering a process re-exec, mutating `sys.stdout`/`sys.stderr`, or reconfiguring the shared logger (#107).
 
 ### Security
 

--- a/kfj_task_extractor.py
+++ b/kfj_task_extractor.py
@@ -42,28 +42,40 @@ import subprocess
 import sys
 from datetime import date, datetime, timezone
 
-# Re-launch inside the project venv when available (same convenience pattern
-# as main.py) so dependencies resolve regardless of the invoking interpreter.
-script_dir = os.path.dirname(os.path.abspath(__file__))
-if os.name == "nt":
-    venv_python = os.path.join(script_dir, ".venv", "Scripts", "python.exe")
-else:
-    venv_python = os.path.join(script_dir, ".venv", "bin", "python")
+def _reexec_in_venv() -> None:
+    """Re-launch inside the project venv when available (same convenience
+    pattern as main.py) so dependencies resolve regardless of the invoking
+    interpreter.
 
-if not sys.executable.startswith(os.path.join(script_dir, ".venv")) and os.path.exists(
-    venv_python
-):
-    print(f"Switching from {sys.executable} to virtual environment: {venv_python}")
-    sys.exit(subprocess.call([venv_python] + sys.argv))
+    No-op when already running from the venv or when the venv does not exist.
+    Called only from the ``__main__`` guard so importing this module never
+    triggers a process re-exec or re-exec loop.
+    """
+    script_dir = os.path.dirname(os.path.abspath(__file__))
+    if os.name == "nt":
+        venv_python = os.path.join(script_dir, ".venv", "Scripts", "python.exe")
+    else:
+        venv_python = os.path.join(script_dir, ".venv", "bin", "python")
 
-# Force UTF-8 output so Unicode survives redirected/cp1252 consoles
-# (e.g. when run under `op run` on Windows)
-for stream in (sys.stdout, sys.stderr):
-    if hasattr(stream, "reconfigure") and (stream.encoding or "").lower() not in (
-        "utf-8",
-        "utf8",
-    ):
-        stream.reconfigure(encoding="utf-8")
+    if not sys.executable.startswith(
+        os.path.join(script_dir, ".venv")
+    ) and os.path.exists(venv_python):
+        print(f"Switching from {sys.executable} to virtual environment: {venv_python}")
+        sys.exit(subprocess.call([venv_python] + sys.argv))
+
+
+def _configure_stdio_encoding() -> None:
+    """Force UTF-8 output so Unicode survives redirected/cp1252 consoles
+    (e.g. when run under ``op run`` on Windows). Mutates sys.stdout/stderr,
+    so it is only invoked from the ``__main__`` guard.
+    """
+    for stream in (sys.stdout, sys.stderr):
+        if hasattr(stream, "reconfigure") and (stream.encoding or "").lower() not in (
+            "utf-8",
+            "utf8",
+        ):
+            stream.reconfigure(encoding="utf-8")
+
 
 try:
     from rich.console import Console
@@ -492,4 +504,9 @@ def main() -> int:
 
 
 if __name__ == "__main__":
+    # Side effects that must only run when executed as a script, never on import:
+    #   1. Re-exec under the project venv if not already running from it.
+    #   2. Reconfigure stdio to UTF-8 (mutates sys.stdout/sys.stderr).
+    _reexec_in_venv()
+    _configure_stdio_encoding()
     sys.exit(main())

--- a/main.py
+++ b/main.py
@@ -91,29 +91,39 @@ def _configure_stdio_encoding() -> None:
                 continue
 
 
-_configure_stdio_encoding()
-
-# Initialize Rich console with proper encoding for cross-platform compatibility
-# This ensures proper rendering on Windows, macOS, and Linux
+# Initialize Rich console with proper encoding for cross-platform compatibility.
+# This ensures proper rendering on Windows, macOS, and Linux. Constructing a
+# Console is a side-effect-free object instantiation (no I/O, no subprocess),
+# so it is safe to do at import time and lets the module's helper functions
+# reference `console` as a module global.
 console = Console(force_terminal=None, legacy_windows=False)
 
-# Setup enhanced logging with Rich
-logger = setup_logging(logging.INFO, use_rich=True)
+# Logging is configured lazily in main() rather than at import time, because
+# setup_logging() mutates the shared "clickup_extractor" logger (clearing and
+# re-adding handlers) and may open a file handler — side effects that should
+# not fire merely from importing this module (e.g. under test/tooling).
+logger = None
 
-# Ensure we're using the virtual environment
-script_dir = os.path.dirname(os.path.abspath(__file__))
-if os.name == "nt":
-    venv_python = os.path.join(script_dir, ".venv", "Scripts", "python.exe")
-else:
-    venv_python = os.path.join(script_dir, ".venv", "bin", "python")
 
-# If we're not running from the venv and the venv exists, restart with the venv Python
-if not sys.executable.startswith(os.path.join(script_dir, ".venv")) and os.path.exists(
-    venv_python
-):
-    print(f"Switching from {sys.executable} to virtual environment: {venv_python}")
-    # Re-execute the script with the virtual environment Python
-    sys.exit(subprocess.call([venv_python] + sys.argv))
+def _reexec_in_venv() -> None:
+    """Re-launch this script under the project's virtualenv interpreter.
+
+    No-op when already running from the venv or when the venv does not exist.
+    Called only from the ``__main__`` guard so that importing this module
+    (for tests/tooling) never triggers a process re-exec or re-exec loop.
+    """
+    script_dir = os.path.dirname(os.path.abspath(__file__))
+    if os.name == "nt":
+        venv_python = os.path.join(script_dir, ".venv", "Scripts", "python.exe")
+    else:
+        venv_python = os.path.join(script_dir, ".venv", "bin", "python")
+
+    if not sys.executable.startswith(
+        os.path.join(script_dir, ".venv")
+    ) and os.path.exists(venv_python):
+        print(f"Switching from {sys.executable} to virtual environment: {venv_python}")
+        # Re-execute the script with the virtual environment Python
+        sys.exit(subprocess.call([venv_python] + sys.argv))
 
 
 def main():
@@ -135,6 +145,11 @@ def main():
     - Add variable: CLICKUP_API_KEY = your ClickUp API key
     - Copy Environment ID and set: export OP_ENVIRONMENT_ID=<environment_id>
     """
+    global logger
+    # Configure logging on first entry into main() rather than at import time.
+    if logger is None:
+        logger = setup_logging(logging.INFO, use_rich=True)
+
     try:
         _ClickUpAPIClient, _ClickUpTaskExtractor = _load_runtime_dependencies()
     except (KeyboardInterrupt, ImportError):
@@ -534,4 +549,9 @@ def main():
 
 
 if __name__ == "__main__":
+    # Side effects that must only run when executed as a script, never on import:
+    #   1. Reconfigure stdio to UTF-8 (mutates sys.stdout/sys.stderr).
+    #   2. Re-exec under the project venv if not already running from it.
+    _configure_stdio_encoding()
+    _reexec_in_venv()
     main()


### PR DESCRIPTION
Fixes #107

## What changed
`main.py` and `kfj_task_extractor.py` ran side effects at import time: the virtualenv re-exec block, UTF-8 stdio reconfiguration, and (in `main.py`) `setup_logging()`. Importing either module — for tests or tooling — therefore risked a process re-exec/re-exec loop, mutated `sys.stdout`/`sys.stderr`, and reconfigured the shared `clickup_extractor` logger. `test_main.py` already had to patch `sys.executable` to a fake venv path just to import `main` safely.

**main.py**
- Moved the venv re-exec into `_reexec_in_venv()`, called only under `__main__`.
- Moved the `_configure_stdio_encoding()` call under `__main__`.
- Deferred `setup_logging()` out of import: module-level `logger` is `None` and is initialized lazily on first entry into `main()`.
- Left `console = Console(...)` at module scope — pure instantiation, referenced by 36 call sites (and the existing test patches `main.console`).

**kfj_task_extractor.py**
- Moved the venv re-exec into `_reexec_in_venv()` and the UTF-8 stdio loop into `_configure_stdio_encoding()`; both called only under `__main__`.
- Left `console`/`logger` (a bare `get_logger`) at module scope — both side-effect-free; `setup_logging()` already ran inside `main()`.

## Testing / self-review
- Import-safety check: importing both modules adds no logging handlers, leaves `logger=None`, performs no re-exec, and does not touch stdio.
- Full `pytest`: **6 failed / 265 passed** — the 6 failures are identical to the pristine `2026-review` tree (tests that make real ClickUp API calls without a key, plus one pre-existing test-isolation ordering case). No new failures introduced; reproduced the same 3-failure set on a stashed/pristine tree to confirm.
- `py_compile` clean on both files.