### PR TITLE
fix: move personal 1Password paths and workspace IDs to config (#106)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,41 @@
+# ClickUp Task Extractor — example environment configuration
+#
+# Copy this file to `.env` and fill in your own values. `.env` is gitignored.
+# These variables replace identifiers that used to be hardcoded in source, so
+# the tool can be configured for any ClickUp account / 1Password vault without
+# editing code. Every variable is optional; unset variables fall back to the
+# documented behavior (CLI args, prompts, or skipping the 1Password lookup).
+
+# --- ClickUp workspace selection -------------------------------------------
+# Workspace (team) name and space name to extract from. Equivalent to the
+# --workspace / --space CLI flags. Leave empty to be prompted / pass on the CLI.
+CLICKUP_WORKSPACE_NAME=
+CLICKUP_SPACE_NAME=
+
+# ClickUp Team/Workspace numeric ID. Only used as a fallback if the workspace
+# name cannot be resolved via the API; the extractor will otherwise prompt.
+CLICKUP_TEAM_ID=
+
+# Optional: override the ClickUp custom-field ID used for the "Summary" field.
+# Defaults to the field id baked into config.py if unset.
+# CLICKUP_AI_SUMMARY_FIELD_ID=
+
+# --- API keys ---------------------------------------------------------------
+# Provide the ClickUp API key directly (highest precedence after --api-key).
+CLICKUP_API_KEY=
+
+# Provide the Gemini API key directly (used for --ai-summary). Equivalent to
+# the --gemini-api-key CLI flag.
+# GEMINI_API_KEY is read via --gemini-api-key; set it on the CLI or via 1Password.
+
+# --- 1Password secret references (optional) ---------------------------------
+# op:// URIs pointing at the items that hold your API keys. When set, the tool
+# resolves the keys from 1Password (SDK / CLI) instead of requiring them inline.
+# Leave empty to skip the 1Password lookup entirely.
+# Example: op://<vault>/<item>/credential
+CLICKUP_API_SECRET_REFERENCE=
+GEMINI_API_SECRET_REFERENCE=
+
+# --- 1Password Environment (optional) ---------------------------------------
+# If you use 1Password Environments, set the Environment ID here.
+OP_ENVIRONMENT_ID=

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -90,7 +90,7 @@ This project leverages MCP (Model Context Protocol) tools for enhanced developme
 ## Integration Points
 
 - **ClickUp API v2**: All data via ClickUp API, robust error handling in `api_client.py`.
-- **1Password**: Secure API key storage/retrieval (SDK preferred, CLI fallback). Reference: `op://Home Server/ClickUp personal API token/credential`.
+- **1Password**: Secure API key storage/retrieval (SDK preferred, CLI fallback). The `op://` reference is configured via `CLICKUP_API_SECRET_REFERENCE` / `GEMINI_API_SECRET_REFERENCE` (see `.env.example`), e.g. `op://<vault>/<item>/credential`.
 - **Google Gemini AI**: Optional summaries, requires API key (see `ai_summary.py`).
 - **Rich**: All console UI (progress, tables, selection).
 
@@ -144,7 +144,7 @@ This project leverages MCP (Model Context Protocol) tools for enhanced developme
 ## Developer workflow
 
 - Requirements live in `requirements.txt`; core deps are `requests`, `rich`, with optional `onepassword-sdk` and `google-genai`—guard imports accordingly.
-- Typical runs: `python main.py` (Markdown export, workspace `KMS`, space `Kikkoman`), or override with `--output-format {Markdown|HTML}`, `--interactive`, `--include-completed`, `--date-filter {AllOpen|ThisWeek|LastWeek}`, and `--ai-summary/--gemini-api-key`.
+- Typical runs: `python main.py` (Markdown export; workspace/space from `--workspace`/`--space` or `CLICKUP_WORKSPACE_NAME`/`CLICKUP_SPACE_NAME`), or override with `--output-format {Markdown|HTML}`, `--interactive`, `--include-completed`, `--date-filter {AllOpen|ThisWeek|LastWeek}`, and `--ai-summary/--gemini-api-key`.
 - The extractor writes to `output/` using the timestamped path from `config.default_output_path()`; exporters adjust the extension per selected format.
 - Version bumps: update `version.py` (`__version__` and related metadata), refresh the README version badge URL, and add a new entry in `docs/CHANGELOG.md` summarizing changes since the previous release.
 - Release builds: Create a `release/v<version>` branch, commit version changes, tag with `v<version>`, and build exe with PyInstaller spec pointing to `dist/v<version>`.

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,9 @@ node_modules/
 .env
 .env.local
 .env.*
+# Keep the committed example templates (they contain no real secrets)
+!.env.example
+!.env.kfj.example
 *.pem
 
 # OS

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,7 +43,8 @@ clickup_task_extractor/
 # Install dependencies
 pip install -r requirements.txt
 
-# Run extractor (defaults: workspace "KMS", space "Kikkoman", Markdown export)
+# Run extractor (Markdown export; workspace/space from --workspace/--space or
+# the CLICKUP_WORKSPACE_NAME/CLICKUP_SPACE_NAME env vars — see .env.example)
 python main.py
 
 # Interactive mode (review/select tasks before export)

--- a/README.md
+++ b/README.md
@@ -54,6 +54,34 @@ A powerful, cross-platform Python application for extracting, processing, and ex
 
 > 💡 The CLI auto-relaunches inside `.venv/` when present, so activating the virtualenv manually is optional as long as dependencies live there.
 
+### ⚙️ Configuration
+
+Account-specific settings are read from environment variables (no personal
+identifiers are hardcoded in source). Copy the example file and fill in your own
+values:
+
+```bash
+cp .env.example .env
+# then edit .env
+```
+
+`.env` is gitignored. The supported variables:
+
+| Variable | Purpose | Default |
+| --- | --- | --- |
+| `CLICKUP_WORKSPACE_NAME` | Workspace (team) name to extract from | empty (use `--workspace` or be prompted) |
+| `CLICKUP_SPACE_NAME` | Space name within the workspace | empty (use `--space` or be prompted) |
+| `CLICKUP_TEAM_ID` | Numeric team ID; fallback when the workspace name can't be resolved | empty (prompted) |
+| `CLICKUP_API_KEY` | ClickUp API key | empty |
+| `CLICKUP_API_SECRET_REFERENCE` | `op://` reference for the ClickUp key in 1Password | empty (1Password lookup skipped) |
+| `GEMINI_API_SECRET_REFERENCE` | `op://` reference for the Gemini key in 1Password | empty (1Password lookup skipped) |
+| `CLICKUP_AI_SUMMARY_FIELD_ID` | Override the "Summary" custom-field ID | built-in field ID |
+| `OP_ENVIRONMENT_ID` | 1Password Environment ID, if you use Environments | empty |
+
+When the `*_SECRET_REFERENCE` variables are empty, the tool skips the 1Password
+lookup and relies on the `CLICKUP_API_KEY` env var, the `--api-key` /
+`--gemini-api-key` flags, or an interactive prompt.
+
 ### Using the Executable
 
 For users who prefer not to install Python, pre-built executables are available:
@@ -97,7 +125,9 @@ ClickUpTaskExtractor.exe --output-format Markdown --interactive
 ### Basic Usage
 
 ```bash
-# Run with default settings (Markdown output, KMS workspace, Kikkoman space)
+# Run with default settings (Markdown output). The workspace and space come
+# from --workspace/--space or the CLICKUP_WORKSPACE_NAME/CLICKUP_SPACE_NAME
+# environment variables (see Configuration below).
 python main.py
 
 # Interactive mode - review tasks before export
@@ -175,7 +205,7 @@ disk.
 ## 🔧 Development workflow
 
 - Install deps via `pip install -r requirements.txt`; optional features require `onepassword-sdk` and `google-genai` which are already listed.
-- Run the extractor with `python main.py` (defaults: workspace `KMS`, space `Kikkoman`, Markdown export). Override with `--output-format`, `--interactive`, `--include-completed`, `--date-filter`, `--ai-summary`, and `--gemini-api-key`.
+- Run the extractor with `python main.py` (Markdown export by default). Set the workspace and space via `--workspace`/`--space` or the `CLICKUP_WORKSPACE_NAME`/`CLICKUP_SPACE_NAME` environment variables (see [Configuration](#-configuration)). Other flags: `--output-format`, `--interactive`, `--include-completed`, `--date-filter`, `--ai-summary`, and `--gemini-api-key`.
 - Authentication falls back in this order: CLI flag → env var `CLICKUP_API_KEY` → 1Password Environment (`OP_ENVIRONMENT_ID`: SDK first, then `op environment read`) → 1Password SDK secret references → `op read` CLI → manual prompt.
 - Logging comes from `logger_config.setup_logging`; pass `use_rich=False` for plain output or a `log_file` path to persist logs.
 - All exports land under `output/`, named with `default_output_path()` which strips leading zeros for cross-platform friendly filenames.
@@ -193,8 +223,8 @@ disk.
 | Option | Description | Default |
 | --- | --- | --- |
 | `--api-key` | ClickUp API key | From environment or 1Password |
-| `--workspace` | Workspace name | `KMS` |
-| `--space` | Space name | `Kikkoman` |
+| `--workspace` | Workspace name | `CLICKUP_WORKSPACE_NAME` env var (else prompted) |
+| `--space` | Space name | `CLICKUP_SPACE_NAME` env var (else prompted) |
 | `--output` | Output file path | Auto-generated timestamp |
 | `--output-format` | Export format: `Markdown` or `HTML` | Prompted if not specified, defaults to `Markdown` |
 | `--include-completed` | Include completed/archived tasks | `False` |

--- a/auth.py
+++ b/auth.py
@@ -210,7 +210,7 @@ def load_secret_with_fallback(secret_reference: str, secret_name: str) -> Secret
 
     Args:
         secret_reference: The 1Password secret reference for vault-based lookups
-                         (e.g., 'op://Home Server/ClickUp personal API token/credential')
+                         (e.g., 'op://<vault>/<item>/credential')
         secret_name: Human-readable name for the secret (for error messages)
 
     Returns:
@@ -415,7 +415,7 @@ def get_secret_from_1password(
     Retrieve a secret from 1Password using the SDK.
 
     Args:
-        secret_reference: The 1Password secret reference (e.g., "op://Home Server/ClickUp personal API token/credential")
+        secret_reference: The 1Password secret reference (e.g., "op://<vault>/<item>/credential")
         secret_type: Description of the secret type for error messages (default: "API key")
 
     Returns:
@@ -477,7 +477,7 @@ def get_api_key_from_1password(secret_reference: str) -> SecretValue:
     Retrieve ClickUp API key from 1Password using the SDK.
 
     Args:
-        secret_reference: The 1Password secret reference (e.g., "op://Home Server/ClickUp personal API token/credential")
+        secret_reference: The 1Password secret reference (e.g., "op://<vault>/<item>/credential")
 
     Returns:
         The API key string if successful, None if failed
@@ -493,7 +493,7 @@ def get_gemini_api_key_from_1password(secret_reference: str) -> SecretValue:
     Retrieve Gemini API key from 1Password using the SDK.
 
     Args:
-        secret_reference: The 1Password secret reference (e.g., "op://Home Server/nftoo3gsi3wpx7z5bdmcsvr7p4/credential")
+        secret_reference: The 1Password secret reference (e.g., "op://<vault>/<item>/credential")
 
     Returns:
         The Gemini API key string if successful, None if failed
@@ -510,5 +510,12 @@ def load_gemini_api_key_from_environment():
     Helper to load Gemini API key from 1Password Environment.
     Uses load_secret_with_fallback which checks OP_ENVIRONMENT_ID automatically.
     """
-    gemini_secret_reference = "op://Home Server/nftoo3gsi3wpx7z5bdmcsvr7p4/credential"
+    # Read the secret reference from configuration (GEMINI_API_SECRET_REFERENCE
+    # env var) rather than hardcoding a personal 1Password path. Imported locally
+    # to avoid any import-order coupling with the config module.
+    from config import GEMINI_API_SECRET_REFERENCE
+
+    gemini_secret_reference = GEMINI_API_SECRET_REFERENCE
+    if not gemini_secret_reference:
+        return None
     return load_secret_with_fallback(gemini_secret_reference, "Gemini API key")

--- a/config.py
+++ b/config.py
@@ -9,6 +9,7 @@ Contains:
 - Date/time formatting constants and utilities
 """
 
+import os
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from typing import Any
@@ -51,8 +52,37 @@ PRIORITY_ORDER = {
 }
 
 
-# Default ClickUp AI summary custom field identifier ("Summary")
-CLICKUP_AI_SUMMARY_FIELD_ID = "d7426f47-27f0-494b-b3a2-7d254132ee1a"
+# Default ClickUp AI summary custom field identifier ("Summary"), overridable
+# via the CLICKUP_AI_SUMMARY_FIELD_ID environment variable.
+CLICKUP_AI_SUMMARY_FIELD_ID = os.environ.get(
+    "CLICKUP_AI_SUMMARY_FIELD_ID", "d7426f47-27f0-494b-b3a2-7d254132ee1a"
+)
+
+
+# ---------------------------------------------------------------------------
+# Account-specific configuration.
+#
+# These values were previously hardcoded as personal defaults in source
+# (a 1Password vault path, a 1Password item id, a ClickUp team id, and the
+# workspace/space names). Hardcoding them exposed internal account structure
+# and made the tool single-tenant. They now read from environment variables
+# with non-personal defaults (empty strings), so anyone can configure the tool
+# for their own account — typically via a local .env file (see .env.example).
+# The owner's previous values can be restored by exporting these variables.
+# ---------------------------------------------------------------------------
+
+# 1Password secret references (op:// URIs) for the API keys. Empty by default;
+# when unset, main.py skips the 1Password lookup and falls back to the
+# CLICKUP_API_KEY / --api-key paths (and a manual prompt) instead.
+CLICKUP_API_SECRET_REFERENCE = os.environ.get("CLICKUP_API_SECRET_REFERENCE", "")
+GEMINI_API_SECRET_REFERENCE = os.environ.get("GEMINI_API_SECRET_REFERENCE", "")
+
+# ClickUp workspace/space names and team id. The extractor resolves the team
+# from the workspace name via the API first, falling back to CLICKUP_TEAM_ID /
+# this team id, then prompting interactively — so empty defaults are safe.
+DEFAULT_WORKSPACE_NAME = os.environ.get("CLICKUP_WORKSPACE_NAME", "")
+DEFAULT_SPACE_NAME = os.environ.get("CLICKUP_SPACE_NAME", "")
+DEFAULT_TEAM_ID = os.environ.get("CLICKUP_TEAM_ID", "")
 
 
 class OutputFormat(Enum):
@@ -289,15 +319,15 @@ class ClickUpConfig:
         ...     api_key="pk_123456789",
         ...     workspace_name="My Workspace",
         ...     space_name="Development",
-        ...     team_id="9014534294"
+        ...     team_id="1234567"
         ... )
     """
 
     api_key: str
-    workspace_name: str = "KMS"
-    space_name: str = "Kikkoman"
+    workspace_name: str = DEFAULT_WORKSPACE_NAME
+    space_name: str = DEFAULT_SPACE_NAME
     list_name: str | None = None
-    team_id: str = "9014534294"
+    team_id: str = DEFAULT_TEAM_ID
     output_path: str = field(default_factory=default_output_path)
     include_completed: bool = False
     date_filter: DateFilter = DateFilter.ALL_OPEN

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated 1Password authentication to use 1Password Environment loading through the Python SDK for `OP_ENVIRONMENT_ID`.
 - Documented the Environment-based flow in the README and setup guidance.
 - Added 1Password CLI Environment fallback using `op environment read <environment_id>` when SDK auth is unavailable.
+- Moved committed personal identifiers (1Password vault paths/item IDs, ClickUp team ID, and the workspace/space names) out of source into environment variables with non-personal (empty) defaults: `CLICKUP_API_SECRET_REFERENCE`, `GEMINI_API_SECRET_REFERENCE`, `CLICKUP_WORKSPACE_NAME`, `CLICKUP_SPACE_NAME`, `CLICKUP_TEAM_ID`, and `CLICKUP_AI_SUMMARY_FIELD_ID`. When a `*_SECRET_REFERENCE` is unset, `main.py` skips the 1Password lookup and falls back to env var / CLI flag / prompt. Added `.env.example` and a README **Configuration** section documenting the variables (#106).
 
 ### Fixed
 

--- a/main.py
+++ b/main.py
@@ -39,6 +39,10 @@ from config import (
     AISource,
     format_datetime,
     CLICKUP_AI_SUMMARY_FIELD_ID,
+    CLICKUP_API_SECRET_REFERENCE,
+    GEMINI_API_SECRET_REFERENCE,
+    DEFAULT_WORKSPACE_NAME,
+    DEFAULT_SPACE_NAME,
 )
 from logger_config import setup_logging
 from mappers import get_choice_input, get_yes_no_input
@@ -183,7 +187,7 @@ def main():
     )
 
     parser = argparse.ArgumentParser(
-        description=f"ClickUp Task Extractor v{__version__} - {__description__}\n\nExtract and export ClickUp tasks to Markdown (default) or HTML. Default workspace: KMS.\nAPI keys can be provided via: 1Password Environment (OP_ENVIRONMENT_ID), environment variables (CLICKUP_API_KEY), or command-line arguments.\n\n1Password Environment Setup: Developer > View Environments > Create new > Add CLICKUP_API_KEY variable > Copy Environment ID > export OP_ENVIRONMENT_ID=<id>",
+        description=f"ClickUp Task Extractor v{__version__} - {__description__}\n\nExtract and export ClickUp tasks to Markdown (default) or HTML. The workspace and space are configured via --workspace/--space or the CLICKUP_WORKSPACE_NAME/CLICKUP_SPACE_NAME environment variables.\nAPI keys can be provided via: 1Password Environment (OP_ENVIRONMENT_ID), environment variables (CLICKUP_API_KEY), or command-line arguments.\n\n1Password Environment Setup: Developer > View Environments > Create new > Add CLICKUP_API_KEY variable > Copy Environment ID > export OP_ENVIRONMENT_ID=<id>",
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
     parser.add_argument(
@@ -201,8 +205,16 @@ def main():
         default=os.environ.get("CLICKUP_API_KEY"),
         help="ClickUp API Key (or set CLICKUP_API_KEY env var). Falls back to 1Password Environment or 1Password SDK (requires OP_SERVICE_ACCOUNT_TOKEN).",
     )
-    parser.add_argument("--workspace", type=str, help="Workspace name (default: KMS)")
-    parser.add_argument("--space", type=str, help="Space name (default: Kikkoman)")
+    parser.add_argument(
+        "--workspace",
+        type=str,
+        help="Workspace name (overrides the CLICKUP_WORKSPACE_NAME env var)",
+    )
+    parser.add_argument(
+        "--space",
+        type=str,
+        help="Space name (overrides the CLICKUP_SPACE_NAME env var)",
+    )
     parser.add_argument(
         "--list", type=str, help="Optional list name to extract from within the space"
     )
@@ -252,7 +264,9 @@ def main():
     )
     args = parser.parse_args()
 
-    # 1Password reference for API key: "op://Home Server/ClickUp personal API token/credential"
+    # The 1Password secret reference for the API key is configured via the
+    # CLICKUP_API_SECRET_REFERENCE environment variable (config module). It is
+    # empty by default so no personal vault path is baked into source.
     api_key = args.api_key or os.environ.get("CLICKUP_API_KEY")
 
     if not api_key:
@@ -284,8 +298,9 @@ def main():
                 style="yellow",
             )
         )
-        secret_reference = "op://Home Server/ClickUp personal API token/credential"
-        api_key = load_secret_with_fallback(secret_reference, "ClickUp API key")
+        secret_reference = CLICKUP_API_SECRET_REFERENCE
+        if secret_reference:
+            api_key = load_secret_with_fallback(secret_reference, "ClickUp API key")
         if not api_key:
             if is_frozen:
                 console.print(
@@ -330,13 +345,14 @@ def main():
         if gemini_api_key:
             return True  # Already have the key
 
-        # Try to get Gemini API key from 1Password with fallback
-        gemini_secret_reference = (
-            "op://Home Server/nftoo3gsi3wpx7z5bdmcsvr7p4/credential"
-        )
-        gemini_api_key = load_secret_with_fallback(
-            gemini_secret_reference, "Gemini API key"
-        )
+        # Try to get Gemini API key from 1Password with fallback. The secret
+        # reference comes from GEMINI_API_SECRET_REFERENCE (config module) and is
+        # empty by default so no personal vault path is baked into source.
+        gemini_secret_reference = GEMINI_API_SECRET_REFERENCE
+        if gemini_secret_reference:
+            gemini_api_key = load_secret_with_fallback(
+                gemini_secret_reference, "Gemini API key"
+            )
         if gemini_api_key:
             return True
         else:
@@ -492,8 +508,8 @@ def main():
 
     config = ClickUpConfig(
         api_key=api_key,
-        workspace_name=args.workspace or "KMS",
-        space_name=args.space or "Kikkoman",
+        workspace_name=args.workspace or DEFAULT_WORKSPACE_NAME,
+        space_name=args.space or DEFAULT_SPACE_NAME,
         list_name=args.list,
         output_path=args.output
         or f"output/WeeklyTaskList_{format_datetime(datetime.now(), TIMESTAMP_FORMAT)}.md",

--- a/tests/test_extractor.py
+++ b/tests/test_extractor.py
@@ -394,6 +394,8 @@ class FetchProcessTasksTests(unittest.TestCase):
             config = ClickUpConfig(
                 api_key="dummy",
                 output_path=str(Path(tmpdir) / "out.md"),
+                workspace_name=workspace_name,
+                space_name=space_name,
                 team_id=team_id,
             )
             api_client = DummyAPIClient(responses)
@@ -459,6 +461,8 @@ class FetchProcessTasksTests(unittest.TestCase):
             config = ClickUpConfig(
                 api_key="dummy",
                 output_path=str(Path(tmpdir) / "out.md"),
+                workspace_name="KMS",
+                space_name="Kikkoman",
                 team_id="team1",
                 list_name="KFI Jefferson",
             )
@@ -531,6 +535,8 @@ class FetchProcessTasksTests(unittest.TestCase):
             config = ClickUpConfig(
                 api_key="dummy",
                 output_path=str(Path(tmpdir) / "out.md"),
+                workspace_name="KMS",
+                space_name="Kikkoman",
                 team_id="team1",
             )
             api_client = DummyAPIClient(responses)


### PR DESCRIPTION
Fixes #106

## What changed
Personal identifiers were hardcoded as code defaults, exposing internal account structure and making the tool single-tenant:
- **main.py** — the 1Password vault paths for the ClickUp key and the Gemini key item.
- **config.py** — `ClickUpConfig` defaults `team_id="9014534294"`, `workspace_name="KMS"`, `space_name="Kikkoman"`.
- **auth.py** — a dead backward-compat helper held the same personal Gemini path; several docstrings embedded the personal vault path.

All now read from environment variables with non-personal (empty) defaults, documented in a new `.env.example`:
- `CLICKUP_API_SECRET_REFERENCE` / `GEMINI_API_SECRET_REFERENCE` (`op://` URIs)
- `CLICKUP_WORKSPACE_NAME` / `CLICKUP_SPACE_NAME` / `CLICKUP_TEAM_ID`
- `CLICKUP_AI_SUMMARY_FIELD_ID` (a field id; keeps its value as the default)

**Behavior:** when a `*_SECRET_REFERENCE` is empty, `main.py` skips the 1Password lookup and relies on `CLICKUP_API_KEY` / `--api-key` / `--gemini-api-key` / a manual prompt. `team_id` resolution already falls back to `CLICKUP_TEAM_ID` then a prompt in `extractor.py`, so empty defaults are safe.

Also updated `.gitignore` (keep `.env.example`/`.env.kfj.example` tracked), and removed the personal `KMS`/`Kikkoman` defaults from `README.md`, `CLAUDE.md`, and `.github/copilot-instructions.md`, adding a README **Configuration** section.

> Note: git history still contains these identifiers in prior commits — this change removes them from the working tree only (no history rewrite).

## Testing / self-review
- Full `pytest`: **6 failed / 265 passed** — identical to the pre-existing baseline (real-API-call tests without a key + one test-isolation case).
- Three `FetchProcessTasksTests` initially broke because they relied on the removed personal `workspace_name`/`space_name` defaults; fixed to pass those explicitly (their mocks already used `KMS`/`Kikkoman`). All 14 extractor tests now pass.
- `py_compile` clean on all changed files.
- Swept tracked source: no `KMS`/`Kikkoman`/team-id/vault-path strings remain outside tests and the historical CHANGELOG entry.