### PR TITLE
feat: pin dependencies with ~= and add lock file (#108)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,10 @@ node_modules/
 !.env.kfj.example
 *.pem
 
+# Dependency lock file is intentionally tracked (some global gitignores
+# exclude *.lock; re-include it here so it is committed everywhere).
+!requirements.lock
+
 # OS
 *.swp
 *.swo

--- a/README.md
+++ b/README.md
@@ -44,7 +44,11 @@ A powerful, cross-platform Python application for extracting, processing, and ex
 2. **Install dependencies:**
 
    ```bash
+   # Normal install — compatible-release (`~=`) pins
    pip install -r requirements.txt
+
+   # Reproducible install — exact transitive versions this project is tested against
+   pip install -r requirements.lock
    ```
 
 3. **Set up your ClickUp API key** (choose one method):
@@ -204,7 +208,7 @@ disk.
 
 ## 🔧 Development workflow
 
-- Install deps via `pip install -r requirements.txt`; optional features require `onepassword-sdk` and `google-genai` which are already listed.
+- Install deps via `pip install -r requirements.txt` (compatible-release `~=` pins) or `pip install -r requirements.lock` for the exact tested versions; optional features require `onepassword-sdk` and `google-genai` which are already listed. Regenerate `requirements.lock` with `pip freeze` from a clean venv after changing `requirements.txt`.
 - Run the extractor with `python main.py` (Markdown export by default). Set the workspace and space via `--workspace`/`--space` or the `CLICKUP_WORKSPACE_NAME`/`CLICKUP_SPACE_NAME` environment variables (see [Configuration](#-configuration)). Other flags: `--output-format`, `--interactive`, `--include-completed`, `--date-filter`, `--ai-summary`, and `--gemini-api-key`.
 - Authentication falls back in this order: CLI flag → env var `CLICKUP_API_KEY` → 1Password Environment (`OP_ENVIRONMENT_ID`: SDK first, then `op environment read`) → 1Password SDK secret references → `op read` CLI → manual prompt.
 - Logging comes from `logger_config.setup_logging`; pass `use_rich=False` for plain output or a `log_file` path to persist logs.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -16,8 +16,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Reuses existing components (`ClickUpAPIClient`, `load_secret_with_fallback`, `TaskRecord`, `sort_tasks_by_priority_and_eta`, `LocationMapper`) without modifying the main extraction workflow.
   - Supports `--dry-run`, `--list-id`, `--sheet-id`, and `--date M/D/YY` overrides.
 - Added `gspread>=6.1.0` dependency for the Google Sheets integration.
+- Added `requirements.lock` — a fully-resolved lock file (`pip freeze` output) for reproducible installs of the exact transitive versions the project is tested against (#108).
 
 ### Changed
+
+- Pinned dependencies with compatible-release (`~=`) specifiers instead of `>=` lower bounds, so breaking major releases of `requests`, `google-genai`, `rich`, or `gspread` cannot be picked up silently. `onepassword-sdk` (still a 0.x beta) is pinned exactly. Use `requirements.lock` for a byte-for-byte reproducible environment (#108).
 
 - Updated 1Password authentication to use 1Password Environment loading through the Python SDK for `OP_ENVIRONMENT_ID`.
 - Documented the Environment-based flow in the README and setup guidance.

--- a/requirements.lock
+++ b/requirements.lock
@@ -1,0 +1,43 @@
+# Fully-resolved dependency lock for ClickUp Task Extractor.
+#
+# Generated with: pip freeze (from a clean venv after 'pip install -r requirements.txt').
+# Provides a reproducible install of the exact transitive versions this
+# project was tested against. For a byte-for-byte reproducible environment:
+#     pip install -r requirements.lock
+# For normal development use requirements.txt (compatible-release pins).
+# Regenerate after changing requirements.txt.
+#
+annotated-types==0.7.0
+anyio==4.14.0
+certifi==2026.5.20
+cffi==2.0.0
+charset-normalizer==3.4.7
+cryptography==49.0.0
+distro==1.9.0
+google-auth==2.55.0
+google-auth-oauthlib==1.4.0
+google-genai==2.8.0
+gspread==6.2.1
+h11==0.16.0
+httpcore==1.0.9
+httpx==0.28.1
+idna==3.18
+markdown-it-py==4.2.0
+mdurl==0.1.2
+oauthlib==3.3.1
+onepassword-sdk==0.4.1b1
+pyasn1==0.6.3
+pyasn1_modules==0.4.2
+pycparser==3.0
+pydantic==2.13.4
+pydantic_core==2.46.4
+Pygments==2.20.0
+requests==2.34.2
+requests-oauthlib==2.0.0
+rich==15.0.0
+sniffio==1.3.1
+tenacity==9.1.4
+typing-inspection==0.4.2
+typing_extensions==4.15.0
+urllib3==2.7.0
+websockets==16.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,18 @@
-requests>=2.25.0
-onepassword-sdk>=0.4.1b1
-google-genai>=1.0.0  # Google Gemini API SDK
-rich>=14.0.0
-gspread>=6.1.0  # Google Sheets client (kfj_task_extractor.py)
+# Dependency pins for ClickUp Task Extractor.
+#
+# Uses compatible-release (`~=`) pins so patch/minor updates are allowed but a
+# breaking MAJOR release cannot be picked up silently. The versions below are
+# the ones this project is tested against (see docs/CHANGELOG.md). Bump the
+# floor deliberately after testing a newer release.
+#
+# `~=X.Y` means ">=X.Y, ==X.*" (any X.Y or newer within the same major).
 
+requests~=2.32          # HTTP client for the ClickUp API
+google-genai~=2.8       # Google Gemini API SDK
+rich~=15.0              # Console UI / logging
+gspread~=6.2            # Google Sheets client (kfj_task_extractor.py)
+
+# 1Password SDK is still a beta (0.x) release and no stable version above 0.4.0
+# is published, so it is pinned exactly rather than with `~=` (a 0.x `~=` pin is
+# effectively an exact pin anyway). Revisit when a stable >=0.4.1 ships.
+onepassword-sdk==0.4.1b1


### PR DESCRIPTION
Fixes #108

## What changed
`requirements.txt` used `>=` lower bounds only with no lock file, so a breaking major release of `google-genai`, `onepassword-sdk`, `gspread`, `requests`, or `rich` could be installed silently and break the tool.

**requirements.txt**
- Switched to compatible-release (`~=`) pins at the tested minor versions: `requests~=2.32`, `google-genai~=2.8`, `rich~=15.0`, `gspread~=6.2`. These allow patch/minor updates but block a breaking MAJOR bump.
- `onepassword-sdk` is still a 0.x beta with no stable release above 0.4.0 published, so it is pinned exactly (`==0.4.1b1`). A 0.x `~=` pin is effectively exact anyway; added a comment to graduate off the beta when a stable `>=0.4.1` ships.

**requirements.lock (new)**
- `pip freeze` output captured from a clean venv built purely from `requirements.txt` — the full transitive closure at the exact tested versions, for reproducible installs (`pip install -r requirements.lock`).
- Added a `!requirements.lock` negation to `.gitignore` because a global `*.lock` rule would otherwise exclude it.

**Docs** — README install/dev notes and `docs/CHANGELOG.md` updated to mention both files and how to regenerate the lock.

## Testing / self-review
- Built a fresh venv and ran `pip install -r requirements.txt` — resolves cleanly to the tested versions.
- Ran the full `pytest` suite **in that pinned venv**: 6 failed / 265 passed — identical to the pre-existing baseline (real-API-call tests without a key + one test-isolation case). No new failures.
- Confirmed `requirements.lock` is tracked (force-added past the global `*.lock` ignore).