### PR TITLE
docs: document and de-hardcode kfj_task_extractor configuration (#110)

### DIFF
--- a/.env.kfj.example
+++ b/.env.kfj.example
@@ -1,0 +1,48 @@
+# Configuration for the standalone weekly sync: kfj_task_extractor.py
+#
+# Copy this file to `.env.kfj` and fill in your own values. `.env.kfj` is
+# gitignored. Load it either by exporting the variables into your shell or by
+# injecting them via 1Password:
+#
+#     op run --account my.1password.com --env-file=.env.kfj -- \
+#         python kfj_task_extractor.py
+#
+# Every variable is optional. The list/sheet ids can also be passed on the CLI
+# (--list-id / --sheet-id), which take precedence over these values.
+
+# --- What to sync -----------------------------------------------------------
+# ClickUp list ID to extract open tasks from. Find it in the ClickUp list URL.
+# Required (via this var or --list-id).
+KFJ_CLICKUP_LIST_ID=
+
+# Google Sheets workbook (spreadsheet) ID to write the weekly tab into. This is
+# the long ID in the sheet URL: https://docs.google.com/spreadsheets/d/<ID>/edit
+# Required unless you run with --dry-run.
+KFJ_GOOGLE_SHEET_ID=
+
+# Optional display tweaks:
+# Prefix for the dated worksheet tab (default: "KFI Jefferson current tasks").
+# KFJ_TAB_PREFIX=KFI Jefferson current tasks
+# Branch label used when a task has no "Branch" custom field value.
+# KFJ_FALLBACK_BRANCH=
+
+# --- Credentials ------------------------------------------------------------
+# Provide the secrets directly (highest precedence). These are read by the
+# resolver before any 1Password lookup is attempted.
+CLICKUP_API_KEY=
+# The Google service-account JSON, as a single-line string.
+GOOGLE_SHEETS_CREDENTIALS_JSON=
+
+# --- 1Password (optional) ---------------------------------------------------
+# op:// references for the two secrets. When set, the script resolves the
+# credentials from 1Password (desktop SDK -> fallback chain -> op CLI). When
+# empty, the 1Password lookup is skipped and the variables above are used.
+# References may use vault/item names or IDs, e.g. op://<vault>/<item>/credential
+KFJ_CLICKUP_SECRET_REFERENCE=
+KFJ_GOOGLE_SA_SECRET_REFERENCE=
+
+# 1Password account selectors. KFJ_OP_ACCOUNT_NAME is the account *display
+# name* shown in the 1Password desktop app (used by the SDK DesktopAuth);
+# KFJ_OP_ACCOUNT_URL is the account URL used by the `op` CLI.
+KFJ_OP_ACCOUNT_NAME=
+KFJ_OP_ACCOUNT_URL=my.1password.com

--- a/README.md
+++ b/README.md
@@ -174,12 +174,44 @@ date, no leading zeros), writes the header and task rows
 ETA, and renames the workbook title to match. Re-running on the same day is
 idempotent — the existing tab's contents are replaced rather than duplicated.
 
+### Configuration
+
+This script has **no hardcoded list, sheet, or account** — point it at your own
+by setting environment variables (copy the template and edit it):
+
 ```bash
-# Standard weekly run (1Password SDK desktop auth resolves both secrets)
+cp .env.kfj.example .env.kfj
+# then edit .env.kfj
+```
+
+`.env.kfj` is gitignored. Supported variables (see `.env.kfj.example` for the
+full list):
+
+| Variable | Purpose | Required? |
+| --- | --- | --- |
+| `KFJ_CLICKUP_LIST_ID` | ClickUp list ID to pull open tasks from (also `--list-id`) | Yes |
+| `KFJ_GOOGLE_SHEET_ID` | Google Sheets workbook ID to write to (also `--sheet-id`) | Yes (unless `--dry-run`) |
+| `KFJ_TAB_PREFIX` | Worksheet tab name prefix | No (default `KFI Jefferson current tasks`) |
+| `KFJ_FALLBACK_BRANCH` | Branch label when a task has no Branch field | No |
+| `CLICKUP_API_KEY` | ClickUp API key (resolved before 1Password) | Provide this or a 1Password reference |
+| `GOOGLE_SHEETS_CREDENTIALS_JSON` | Google service-account JSON (single line) | Provide this or a 1Password reference |
+| `KFJ_CLICKUP_SECRET_REFERENCE` | `op://` reference for the ClickUp key | No (skips 1Password if empty) |
+| `KFJ_GOOGLE_SA_SECRET_REFERENCE` | `op://` reference for the service-account JSON | No (skips 1Password if empty) |
+| `KFJ_OP_ACCOUNT_NAME` / `KFJ_OP_ACCOUNT_URL` | 1Password account display name / URL | No |
+
+> Finding the IDs: the **list ID** is the number in the ClickUp list URL; the
+> **sheet ID** is the long ID in the Google Sheets URL
+> (`https://docs.google.com/spreadsheets/d/<ID>/edit`).
+
+```bash
+# Standard weekly run (reads .env.kfj from your shell; 1Password resolves secrets)
 python kfj_task_extractor.py
 
-# Preview the rows without touching Google Sheets
+# Preview the rows without touching Google Sheets (no sheet ID required)
 python kfj_task_extractor.py --dry-run
+
+# Override the list/sheet on the CLI
+python kfj_task_extractor.py --list-id <LIST_ID> --sheet-id <SHEET_ID>
 
 # Inject secrets explicitly via op run (fallback path)
 op run --account my.1password.com --env-file=.env.kfj -- python kfj_task_extractor.py
@@ -187,16 +219,16 @@ op run --account my.1password.com --env-file=.env.kfj -- python kfj_task_extract
 
 | Option | Description | Default |
 | --- | --- | --- |
-| `--list-id` | ClickUp list ID to extract from | `901413205844` (KFI Jefferson) |
-| `--sheet-id` | Google Sheets workbook ID to write to | Built-in weekly sheet |
+| `--list-id` | ClickUp list ID to extract from | `KFJ_CLICKUP_LIST_ID` env var |
+| `--sheet-id` | Google Sheets workbook ID to write to | `KFJ_GOOGLE_SHEET_ID` env var |
 | `--dry-run` | Fetch and print rows without writing to Sheets | `False` |
 | `--date M/D/YY` | Override the date used in the tab name (for backfill) | Today |
 
 **Authentication:** ClickUp uses `CLICKUP_API_KEY` from the environment first,
-then the 1Password SDK, then the repo's fallback chain. The Google service
-account JSON is resolved the same way (env var `GOOGLE_SHEETS_CREDENTIALS_JSON`
-→ 1Password SDK → CLI) and parsed in-memory — credentials are never written to
-disk.
+then (if `KFJ_CLICKUP_SECRET_REFERENCE` is set) the 1Password SDK and the repo's
+fallback chain. The Google service account JSON is resolved the same way (env
+var `GOOGLE_SHEETS_CREDENTIALS_JSON` → 1Password if `KFJ_GOOGLE_SA_SECRET_REFERENCE`
+is set) and parsed in-memory — credentials are never written to disk.
 
 **One-time setup** before the first real run:
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Pinned dependencies with compatible-release (`~=`) specifiers instead of `>=` lower bounds, so breaking major releases of `requests`, `google-genai`, `rich`, or `gspread` cannot be picked up silently. `onepassword-sdk` (still a 0.x beta) is pinned exactly. Use `requirements.lock` for a byte-for-byte reproducible environment (#108).
+- Made `kfj_task_extractor.py` configurable instead of single-tenant: the ClickUp list ID, Google Sheet ID, 1Password secret references, and 1Password account name/URL now read from `KFJ_*` environment variables with non-personal (empty) defaults. `--list-id`/`--sheet-id` still override, and `main()` now errors clearly when no list/sheet is configured. Added `.env.kfj.example` and a README **Configuration** subsection documenting every variable and where to find the IDs (#110).
 
 - Updated 1Password authentication to use 1Password Environment loading through the Python SDK for `OP_ENVIRONMENT_ID`.
 - Documented the Environment-based flow in the README and setup guidance.

--- a/kfj_task_extractor.py
+++ b/kfj_task_extractor.py
@@ -94,30 +94,41 @@ from mappers import LocationMapper
 console = Console()
 logger = get_logger(__name__)
 
-DEFAULT_LIST_ID = "901413205844"  # ClickUp list "KFI Jefferson"
-DEFAULT_SHEET_ID = "13plvMvZDvF5qIEhdDzJIhgoM1TdNoe9KZ1673AiAJ50"
-TAB_PREFIX = "KFI Jefferson current tasks"
+# ---------------------------------------------------------------------------
+# Configuration.
+#
+# The values below were previously hardcoded as personal defaults (a ClickUp
+# list id, a Google Sheet id, 1Password vault/item references, and a 1Password
+# account name), which made this script single-tenant. They now read from
+# environment variables with non-personal (empty) defaults so the script can be
+# pointed at any list/sheet/account — typically via a local .env.kfj file (see
+# .env.kfj.example). The list/sheet ids can also be passed on the CLI with
+# --list-id / --sheet-id, which take precedence over these defaults.
+# ---------------------------------------------------------------------------
+
+# ClickUp list id and Google Sheets workbook id (empty by default).
+DEFAULT_LIST_ID = os.environ.get("KFJ_CLICKUP_LIST_ID", "")
+DEFAULT_SHEET_ID = os.environ.get("KFJ_GOOGLE_SHEET_ID", "")
+
+TAB_PREFIX = os.environ.get("KFJ_TAB_PREFIX", "KFI Jefferson current tasks")
 HEADER = ["Task", "Company", "Branch", "Priority", "Status", "ETA"]
-FALLBACK_BRANCH = "KFJ (213)"
+FALLBACK_BRANCH = os.environ.get("KFJ_FALLBACK_BRANCH", "")
 PRIORITY_MAP = {1: "Low", 2: "Normal", 3: "High", 4: "Urgent"}
 SCOPES = ["https://www.googleapis.com/auth/spreadsheets"]
-# Both secrets live in the "Dev" vault (ksvblaaxovsjqoanl4dzo2apdu) of the
-# personal 1Password account, so a single authentication covers both.
-# References use vault/item IDs (not names): the 1Password desktop SDK
-# integration only matches vaults by ID, IDs survive renames, and they work
-# everywhere else too (op CLI, op run, service-token SDK).
-# Item "ClickUp personal API token":
-CLICKUP_SECRET_REFERENCE = (
-    "op://ksvblaaxovsjqoanl4dzo2apdu/ClickUp personal API token/credential"
-)
-# Item "GC SDK service account":
-GOOGLE_SA_SECRET_REFERENCE = (
-    "op://ksvblaaxovsjqoanl4dzo2apdu/q6cioe2ngge2k2mpf2ojps77la/credential"
-)
-# DesktopAuth expects the account *display name* as shown in the 1Password
-# app; the op CLI expects the account URL.
-PERSONAL_ACCOUNT_NAME = "Maffiola Family"
-PERSONAL_ACCOUNT_URL = "my.1password.com"
+
+# 1Password secret references (op:// URIs) for the ClickUp API key and the
+# Google service-account JSON. Both default to empty; when unset, the resolver
+# falls back to the KFJ_*/standard environment variables (see _resolve_secret).
+# References may use vault/item IDs or names; IDs survive renames and work with
+# the desktop SDK, op CLI, op run, and service-token SDK.
+CLICKUP_SECRET_REFERENCE = os.environ.get("KFJ_CLICKUP_SECRET_REFERENCE", "")
+# Service-account JSON item:
+GOOGLE_SA_SECRET_REFERENCE = os.environ.get("KFJ_GOOGLE_SA_SECRET_REFERENCE", "")
+
+# 1Password account selectors. DesktopAuth expects the account *display name*
+# as shown in the 1Password app; the op CLI expects the account URL.
+PERSONAL_ACCOUNT_NAME = os.environ.get("KFJ_OP_ACCOUNT_NAME", "")
+PERSONAL_ACCOUNT_URL = os.environ.get("KFJ_OP_ACCOUNT_URL", "my.1password.com")
 
 
 def read_secret_via_op_cli(
@@ -173,8 +184,16 @@ def _resolve_secret(
     if value:
         logger.debug(f"Using {secret_name} from environment variable {env_var}")
         return value
+    # Without a configured 1Password reference, skip the 1Password lookups and
+    # rely on the environment variable above (e.g. injected via `op run`).
+    if not secret_reference:
+        logger.debug(
+            f"No 1Password reference configured for {secret_name}; "
+            f"set {env_var} or KFJ_*_SECRET_REFERENCE to enable 1Password lookup."
+        )
+        return None
     value = resolve_secret_with_desktop_sdk(
-        secret_reference, secret_name, [sdk_account_name]
+        secret_reference, secret_name, [sdk_account_name] if sdk_account_name else []
     )
     if value:
         return value
@@ -396,12 +415,14 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--list-id",
         default=DEFAULT_LIST_ID,
-        help=f"ClickUp list ID to extract from (default: {DEFAULT_LIST_ID})",
+        help="ClickUp list ID to extract from "
+        "(default: KFJ_CLICKUP_LIST_ID env var)",
     )
     parser.add_argument(
         "--sheet-id",
         default=DEFAULT_SHEET_ID,
-        help="Google Sheets workbook ID to write to",
+        help="Google Sheets workbook ID to write to "
+        "(default: KFJ_GOOGLE_SHEET_ID env var)",
     )
     parser.add_argument(
         "--dry-run",
@@ -421,6 +442,21 @@ def main() -> int:
     """Run the extraction and sheet update. Returns process exit code."""
     setup_logging(logging.INFO)
     args = parse_args()
+
+    # The list/sheet ids are no longer hardcoded; require them via --list-id /
+    # --sheet-id or the KFJ_CLICKUP_LIST_ID / KFJ_GOOGLE_SHEET_ID env vars.
+    if not args.list_id:
+        console.print(
+            "[red]No ClickUp list ID configured. Pass --list-id or set "
+            "KFJ_CLICKUP_LIST_ID (see .env.kfj.example).[/red]"
+        )
+        return 1
+    if not args.sheet_id and not args.dry_run:
+        console.print(
+            "[red]No Google Sheet ID configured. Pass --sheet-id or set "
+            "KFJ_GOOGLE_SHEET_ID (see .env.kfj.example), or use --dry-run.[/red]"
+        )
+        return 1
 
     if args.date:
         try:

--- a/tests/test_kfj_task_extractor.py
+++ b/tests/test_kfj_task_extractor.py
@@ -285,6 +285,10 @@ class TestCredentialResolution(unittest.TestCase):
         with mock.patch.dict(os.environ, {}, clear=True):
             with (
                 mock.patch(
+                    "kfj_task_extractor.CLICKUP_SECRET_REFERENCE",
+                    "op://vault/item/credential",
+                ),
+                mock.patch(
                     "kfj_task_extractor.resolve_secret_with_desktop_sdk",
                     return_value="pk_from_sdk",
                 ) as sdk,
@@ -299,6 +303,10 @@ class TestCredentialResolution(unittest.TestCase):
     def test_clickup_key_falls_back_when_sdk_fails(self):
         with mock.patch.dict(os.environ, {}, clear=True):
             with (
+                mock.patch(
+                    "kfj_task_extractor.CLICKUP_SECRET_REFERENCE",
+                    "op://vault/item/credential",
+                ),
                 mock.patch(
                     "kfj_task_extractor.resolve_secret_with_desktop_sdk",
                     return_value=None,
@@ -325,6 +333,10 @@ class TestCredentialResolution(unittest.TestCase):
         with mock.patch.dict(os.environ, {}, clear=True):
             with (
                 mock.patch(
+                    "kfj_task_extractor.GOOGLE_SA_SECRET_REFERENCE",
+                    "op://vault/item/credential",
+                ),
+                mock.patch(
                     "kfj_task_extractor.resolve_secret_with_desktop_sdk",
                     return_value='{"type": "service_account"}',
                 ) as sdk,
@@ -342,6 +354,10 @@ class TestCredentialResolution(unittest.TestCase):
         with mock.patch.dict(os.environ, {}, clear=True):
             with (
                 mock.patch(
+                    "kfj_task_extractor.GOOGLE_SA_SECRET_REFERENCE",
+                    "op://vault/item/credential",
+                ),
+                mock.patch(
                     "kfj_task_extractor.resolve_secret_with_desktop_sdk",
                     return_value=None,
                 ),
@@ -356,6 +372,25 @@ class TestCredentialResolution(unittest.TestCase):
             ):
                 self.assertIsNone(load_google_credentials_json())
                 op_cli.assert_called_once()
+
+    def test_clickup_key_skips_1password_when_reference_unset(self):
+        """With no env var and an empty secret reference, the 1Password chain is
+        skipped and resolution returns None (issue #110)."""
+        with mock.patch.dict(os.environ, {}, clear=True):
+            with (
+                mock.patch("kfj_task_extractor.CLICKUP_SECRET_REFERENCE", ""),
+                mock.patch(
+                    "kfj_task_extractor.resolve_secret_with_desktop_sdk",
+                    return_value="should_not_be_used",
+                ) as sdk,
+                mock.patch(
+                    "kfj_task_extractor.load_secret_with_fallback",
+                    return_value="should_not_be_used",
+                ) as fallback,
+            ):
+                self.assertIsNone(resolve_clickup_api_key())
+                sdk.assert_not_called()
+                fallback.assert_not_called()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes #110

## What changed
`kfj_task_extractor.py` hardcoded a personal ClickUp list ID and Google Sheet ID (plus personal 1Password references and account name) and required a Sheet ID at runtime with no documentation of which spreadsheet was expected — making the script effectively single-tenant.

**De-hardcoded into `KFJ_*` env vars (non-personal empty defaults):**
- `KFJ_CLICKUP_LIST_ID`, `KFJ_GOOGLE_SHEET_ID`, `KFJ_TAB_PREFIX`, `KFJ_FALLBACK_BRANCH`
- `KFJ_CLICKUP_SECRET_REFERENCE`, `KFJ_GOOGLE_SA_SECRET_REFERENCE`
- `KFJ_OP_ACCOUNT_NAME`, `KFJ_OP_ACCOUNT_URL`

**Behavior**
- `_resolve_secret()` short-circuits to `None` (after the direct env-var check) when no 1Password reference is configured, instead of attempting lookups with an empty reference.
- `main()` errors clearly when no list ID is configured, and when no sheet ID is configured unless `--dry-run`, pointing at `.env.kfj.example`.
- `--list-id`/`--sheet-id` help text references the env vars instead of exposing personal defaults.

**Documentation (the core of the issue)**
- Added `.env.kfj.example` documenting every variable, the credential options, and how to find the list/sheet IDs.
- Expanded the README "Weekly KFI Jefferson Sheet Sync" section with a **Configuration** subsection (variable table + ID-location notes) and updated the CLI examples and option-default table.

> Note: git history still contains the personal identifiers — removed from the working tree only (no history rewrite).

## Testing / self-review
- Updated four `TestCredentialResolution` cases to patch the module's secret reference to a non-empty value (they exercise the 1Password chain, now skipped when empty); added a test asserting the chain is skipped and `None` returned when unconfigured.
- Full `pytest`: **6 failed / 266 passed** — same pre-existing failures as baseline plus one new passing kfj test.
- `py_compile` clean; swept source — no personal list/sheet/vault/account identifiers remain outside tests and the historical CHANGELOG.