### PR TITLE
2026 review: clickup_task_extractor fixes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,41 @@
+# ClickUp Task Extractor — example environment configuration
+#
+# Copy this file to `.env` and fill in your own values. `.env` is gitignored.
+# These variables replace identifiers that used to be hardcoded in source, so
+# the tool can be configured for any ClickUp account / 1Password vault without
+# editing code. Every variable is optional; unset variables fall back to the
+# documented behavior (CLI args, prompts, or skipping the 1Password lookup).
+
+# --- ClickUp workspace selection -------------------------------------------
+# Workspace (team) name and space name to extract from. Equivalent to the
+# --workspace / --space CLI flags. Leave empty to be prompted / pass on the CLI.
+CLICKUP_WORKSPACE_NAME=
+CLICKUP_SPACE_NAME=
+
+# ClickUp Team/Workspace numeric ID. Only used as a fallback if the workspace
+# name cannot be resolved via the API; the extractor will otherwise prompt.
+CLICKUP_TEAM_ID=
+
+# Optional: override the ClickUp custom-field ID used for the "Summary" field.
+# Defaults to the field id baked into config.py if unset.
+# CLICKUP_AI_SUMMARY_FIELD_ID=
+
+# --- API keys ---------------------------------------------------------------
+# Provide the ClickUp API key directly (highest precedence after --api-key).
+CLICKUP_API_KEY=
+
+# Provide the Gemini API key directly (used for --ai-summary). Equivalent to
+# the --gemini-api-key CLI flag.
+# GEMINI_API_KEY is read via --gemini-api-key; set it on the CLI or via 1Password.
+
+# --- 1Password secret references (optional) ---------------------------------
+# op:// URIs pointing at the items that hold your API keys. When set, the tool
+# resolves the keys from 1Password (SDK / CLI) instead of requiring them inline.
+# Leave empty to skip the 1Password lookup entirely.
+# Example: op://<vault>/<item>/credential
+CLICKUP_API_SECRET_REFERENCE=
+GEMINI_API_SECRET_REFERENCE=
+
+# --- 1Password Environment (optional) ---------------------------------------
+# If you use 1Password Environments, set the Environment ID here.
+OP_ENVIRONMENT_ID=

--- a/.env.kfj.example
+++ b/.env.kfj.example
@@ -1,0 +1,48 @@
+# Configuration for the standalone weekly sync: kfj_task_extractor.py
+#
+# Copy this file to `.env.kfj` and fill in your own values. `.env.kfj` is
+# gitignored. Load it either by exporting the variables into your shell or by
+# injecting them via 1Password:
+#
+#     op run --account my.1password.com --env-file=.env.kfj -- \
+#         python kfj_task_extractor.py
+#
+# Every variable is optional. The list/sheet ids can also be passed on the CLI
+# (--list-id / --sheet-id), which take precedence over these values.
+
+# --- What to sync -----------------------------------------------------------
+# ClickUp list ID to extract open tasks from. Find it in the ClickUp list URL.
+# Required (via this var or --list-id).
+KFJ_CLICKUP_LIST_ID=
+
+# Google Sheets workbook (spreadsheet) ID to write the weekly tab into. This is
+# the long ID in the sheet URL: https://docs.google.com/spreadsheets/d/<ID>/edit
+# Required unless you run with --dry-run.
+KFJ_GOOGLE_SHEET_ID=
+
+# Optional display tweaks:
+# Prefix for the dated worksheet tab (default: "KFI Jefferson current tasks").
+# KFJ_TAB_PREFIX=KFI Jefferson current tasks
+# Branch label used when a task has no "Branch" custom field value.
+# KFJ_FALLBACK_BRANCH=
+
+# --- Credentials ------------------------------------------------------------
+# Provide the secrets directly (highest precedence). These are read by the
+# resolver before any 1Password lookup is attempted.
+CLICKUP_API_KEY=
+# The Google service-account JSON, as a single-line string.
+GOOGLE_SHEETS_CREDENTIALS_JSON=
+
+# --- 1Password (optional) ---------------------------------------------------
+# op:// references for the two secrets. When set, the script resolves the
+# credentials from 1Password (desktop SDK -> fallback chain -> op CLI). When
+# empty, the 1Password lookup is skipped and the variables above are used.
+# References may use vault/item names or IDs, e.g. op://<vault>/<item>/credential
+KFJ_CLICKUP_SECRET_REFERENCE=
+KFJ_GOOGLE_SA_SECRET_REFERENCE=
+
+# 1Password account selectors. KFJ_OP_ACCOUNT_NAME is the account *display
+# name* shown in the 1Password desktop app (used by the SDK DesktopAuth);
+# KFJ_OP_ACCOUNT_URL is the account URL used by the `op` CLI.
+KFJ_OP_ACCOUNT_NAME=
+KFJ_OP_ACCOUNT_URL=my.1password.com

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -90,7 +90,7 @@ This project leverages MCP (Model Context Protocol) tools for enhanced developme
 ## Integration Points
 
 - **ClickUp API v2**: All data via ClickUp API, robust error handling in `api_client.py`.
-- **1Password**: Secure API key storage/retrieval (SDK preferred, CLI fallback). Reference: `op://Home Server/ClickUp personal API token/credential`.
+- **1Password**: Secure API key storage/retrieval (SDK preferred, CLI fallback). The `op://` reference is configured via `CLICKUP_API_SECRET_REFERENCE` / `GEMINI_API_SECRET_REFERENCE` (see `.env.example`), e.g. `op://<vault>/<item>/credential`.
 - **Google Gemini AI**: Optional summaries, requires API key (see `ai_summary.py`).
 - **Rich**: All console UI (progress, tables, selection).
 
@@ -144,7 +144,7 @@ This project leverages MCP (Model Context Protocol) tools for enhanced developme
 ## Developer workflow
 
 - Requirements live in `requirements.txt`; core deps are `requests`, `rich`, with optional `onepassword-sdk` and `google-genai`—guard imports accordingly.
-- Typical runs: `python main.py` (Markdown export, workspace `KMS`, space `Kikkoman`), or override with `--output-format {Markdown|HTML}`, `--interactive`, `--include-completed`, `--date-filter {AllOpen|ThisWeek|LastWeek}`, and `--ai-summary/--gemini-api-key`.
+- Typical runs: `python main.py` (Markdown export; workspace/space from `--workspace`/`--space` or `CLICKUP_WORKSPACE_NAME`/`CLICKUP_SPACE_NAME`), or override with `--output-format {Markdown|HTML}`, `--interactive`, `--include-completed`, `--date-filter {AllOpen|ThisWeek|LastWeek}`, and `--ai-summary/--gemini-api-key`.
 - The extractor writes to `output/` using the timestamped path from `config.default_output_path()`; exporters adjust the extension per selected format.
 - Version bumps: update `version.py` (`__version__` and related metadata), refresh the README version badge URL, and add a new entry in `docs/CHANGELOG.md` summarizing changes since the previous release.
 - Release builds: Create a `release/v<version>` branch, commit version changes, tag with `v<version>`, and build exe with PyInstaller spec pointing to `dist/v<version>`.

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,9 @@ node_modules/
 .env
 .env.local
 .env.*
+# Keep the committed example templates (they contain no real secrets)
+!.env.example
+!.env.kfj.example
 *.pem
 
 # OS

--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,10 @@ node_modules/
 !.env.kfj.example
 *.pem
 
+# Dependency lock file is intentionally tracked (some global gitignores
+# exclude *.lock; re-include it here so it is committed everywhere).
+!requirements.lock
+
 # OS
 *.swp
 *.swo

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,7 +43,8 @@ clickup_task_extractor/
 # Install dependencies
 pip install -r requirements.txt
 
-# Run extractor (defaults: workspace "KMS", space "Kikkoman", Markdown export)
+# Run extractor (Markdown export; workspace/space from --workspace/--space or
+# the CLICKUP_WORKSPACE_NAME/CLICKUP_SPACE_NAME env vars — see .env.example)
 python main.py
 
 # Interactive mode (review/select tasks before export)

--- a/README.md
+++ b/README.md
@@ -174,12 +174,44 @@ date, no leading zeros), writes the header and task rows
 ETA, and renames the workbook title to match. Re-running on the same day is
 idempotent — the existing tab's contents are replaced rather than duplicated.
 
+### Configuration
+
+This script has **no hardcoded list, sheet, or account** — point it at your own
+by setting environment variables (copy the template and edit it):
+
 ```bash
-# Standard weekly run (1Password SDK desktop auth resolves both secrets)
+cp .env.kfj.example .env.kfj
+# then edit .env.kfj
+```
+
+`.env.kfj` is gitignored. Supported variables (see `.env.kfj.example` for the
+full list):
+
+| Variable | Purpose | Required? |
+| --- | --- | --- |
+| `KFJ_CLICKUP_LIST_ID` | ClickUp list ID to pull open tasks from (also `--list-id`) | Yes |
+| `KFJ_GOOGLE_SHEET_ID` | Google Sheets workbook ID to write to (also `--sheet-id`) | Yes (unless `--dry-run`) |
+| `KFJ_TAB_PREFIX` | Worksheet tab name prefix | No (default `KFI Jefferson current tasks`) |
+| `KFJ_FALLBACK_BRANCH` | Branch label when a task has no Branch field | No |
+| `CLICKUP_API_KEY` | ClickUp API key (resolved before 1Password) | Provide this or a 1Password reference |
+| `GOOGLE_SHEETS_CREDENTIALS_JSON` | Google service-account JSON (single line) | Provide this or a 1Password reference |
+| `KFJ_CLICKUP_SECRET_REFERENCE` | `op://` reference for the ClickUp key | No (skips 1Password if empty) |
+| `KFJ_GOOGLE_SA_SECRET_REFERENCE` | `op://` reference for the service-account JSON | No (skips 1Password if empty) |
+| `KFJ_OP_ACCOUNT_NAME` / `KFJ_OP_ACCOUNT_URL` | 1Password account display name / URL | No |
+
+> Finding the IDs: the **list ID** is the number in the ClickUp list URL; the
+> **sheet ID** is the long ID in the Google Sheets URL
+> (`https://docs.google.com/spreadsheets/d/<ID>/edit`).
+
+```bash
+# Standard weekly run (reads .env.kfj from your shell; 1Password resolves secrets)
 python kfj_task_extractor.py
 
-# Preview the rows without touching Google Sheets
+# Preview the rows without touching Google Sheets (no sheet ID required)
 python kfj_task_extractor.py --dry-run
+
+# Override the list/sheet on the CLI
+python kfj_task_extractor.py --list-id <LIST_ID> --sheet-id <SHEET_ID>
 
 # Inject secrets explicitly via op run (fallback path)
 op run --account my.1password.com --env-file=.env.kfj -- python kfj_task_extractor.py
@@ -187,16 +219,16 @@ op run --account my.1password.com --env-file=.env.kfj -- python kfj_task_extract
 
 | Option | Description | Default |
 | --- | --- | --- |
-| `--list-id` | ClickUp list ID to extract from | `901413205844` (KFI Jefferson) |
-| `--sheet-id` | Google Sheets workbook ID to write to | Built-in weekly sheet |
+| `--list-id` | ClickUp list ID to extract from | `KFJ_CLICKUP_LIST_ID` env var |
+| `--sheet-id` | Google Sheets workbook ID to write to | `KFJ_GOOGLE_SHEET_ID` env var |
 | `--dry-run` | Fetch and print rows without writing to Sheets | `False` |
 | `--date M/D/YY` | Override the date used in the tab name (for backfill) | Today |
 
 **Authentication:** ClickUp uses `CLICKUP_API_KEY` from the environment first,
-then the 1Password SDK, then the repo's fallback chain. The Google service
-account JSON is resolved the same way (env var `GOOGLE_SHEETS_CREDENTIALS_JSON`
-→ 1Password SDK → CLI) and parsed in-memory — credentials are never written to
-disk.
+then (if `KFJ_CLICKUP_SECRET_REFERENCE` is set) the 1Password SDK and the repo's
+fallback chain. The Google service account JSON is resolved the same way (env
+var `GOOGLE_SHEETS_CREDENTIALS_JSON` → 1Password if `KFJ_GOOGLE_SA_SECRET_REFERENCE`
+is set) and parsed in-memory — credentials are never written to disk.
 
 **One-time setup** before the first real run:
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,11 @@ A powerful, cross-platform Python application for extracting, processing, and ex
 2. **Install dependencies:**
 
    ```bash
+   # Normal install — compatible-release (`~=`) pins
    pip install -r requirements.txt
+
+   # Reproducible install — exact transitive versions this project is tested against
+   pip install -r requirements.lock
    ```
 
 3. **Set up your ClickUp API key** (choose one method):
@@ -204,7 +208,7 @@ disk.
 
 ## 🔧 Development workflow
 
-- Install deps via `pip install -r requirements.txt`; optional features require `onepassword-sdk` and `google-genai` which are already listed.
+- Install deps via `pip install -r requirements.txt` (compatible-release `~=` pins) or `pip install -r requirements.lock` for the exact tested versions; optional features require `onepassword-sdk` and `google-genai` which are already listed. Regenerate `requirements.lock` with `pip freeze` from a clean venv after changing `requirements.txt`.
 - Run the extractor with `python main.py` (Markdown export by default). Set the workspace and space via `--workspace`/`--space` or the `CLICKUP_WORKSPACE_NAME`/`CLICKUP_SPACE_NAME` environment variables (see [Configuration](#-configuration)). Other flags: `--output-format`, `--interactive`, `--include-completed`, `--date-filter`, `--ai-summary`, and `--gemini-api-key`.
 - Authentication falls back in this order: CLI flag → env var `CLICKUP_API_KEY` → 1Password Environment (`OP_ENVIRONMENT_ID`: SDK first, then `op environment read`) → 1Password SDK secret references → `op read` CLI → manual prompt.
 - Logging comes from `logger_config.setup_logging`; pass `use_rich=False` for plain output or a `log_file` path to persist logs.

--- a/README.md
+++ b/README.md
@@ -54,6 +54,34 @@ A powerful, cross-platform Python application for extracting, processing, and ex
 
 > 💡 The CLI auto-relaunches inside `.venv/` when present, so activating the virtualenv manually is optional as long as dependencies live there.
 
+### ⚙️ Configuration
+
+Account-specific settings are read from environment variables (no personal
+identifiers are hardcoded in source). Copy the example file and fill in your own
+values:
+
+```bash
+cp .env.example .env
+# then edit .env
+```
+
+`.env` is gitignored. The supported variables:
+
+| Variable | Purpose | Default |
+| --- | --- | --- |
+| `CLICKUP_WORKSPACE_NAME` | Workspace (team) name to extract from | empty (use `--workspace` or be prompted) |
+| `CLICKUP_SPACE_NAME` | Space name within the workspace | empty (use `--space` or be prompted) |
+| `CLICKUP_TEAM_ID` | Numeric team ID; fallback when the workspace name can't be resolved | empty (prompted) |
+| `CLICKUP_API_KEY` | ClickUp API key | empty |
+| `CLICKUP_API_SECRET_REFERENCE` | `op://` reference for the ClickUp key in 1Password | empty (1Password lookup skipped) |
+| `GEMINI_API_SECRET_REFERENCE` | `op://` reference for the Gemini key in 1Password | empty (1Password lookup skipped) |
+| `CLICKUP_AI_SUMMARY_FIELD_ID` | Override the "Summary" custom-field ID | built-in field ID |
+| `OP_ENVIRONMENT_ID` | 1Password Environment ID, if you use Environments | empty |
+
+When the `*_SECRET_REFERENCE` variables are empty, the tool skips the 1Password
+lookup and relies on the `CLICKUP_API_KEY` env var, the `--api-key` /
+`--gemini-api-key` flags, or an interactive prompt.
+
 ### Using the Executable
 
 For users who prefer not to install Python, pre-built executables are available:
@@ -97,7 +125,9 @@ ClickUpTaskExtractor.exe --output-format Markdown --interactive
 ### Basic Usage
 
 ```bash
-# Run with default settings (Markdown output, KMS workspace, Kikkoman space)
+# Run with default settings (Markdown output). The workspace and space come
+# from --workspace/--space or the CLICKUP_WORKSPACE_NAME/CLICKUP_SPACE_NAME
+# environment variables (see Configuration below).
 python main.py
 
 # Interactive mode - review tasks before export
@@ -175,7 +205,7 @@ disk.
 ## 🔧 Development workflow
 
 - Install deps via `pip install -r requirements.txt`; optional features require `onepassword-sdk` and `google-genai` which are already listed.
-- Run the extractor with `python main.py` (defaults: workspace `KMS`, space `Kikkoman`, Markdown export). Override with `--output-format`, `--interactive`, `--include-completed`, `--date-filter`, `--ai-summary`, and `--gemini-api-key`.
+- Run the extractor with `python main.py` (Markdown export by default). Set the workspace and space via `--workspace`/`--space` or the `CLICKUP_WORKSPACE_NAME`/`CLICKUP_SPACE_NAME` environment variables (see [Configuration](#-configuration)). Other flags: `--output-format`, `--interactive`, `--include-completed`, `--date-filter`, `--ai-summary`, and `--gemini-api-key`.
 - Authentication falls back in this order: CLI flag → env var `CLICKUP_API_KEY` → 1Password Environment (`OP_ENVIRONMENT_ID`: SDK first, then `op environment read`) → 1Password SDK secret references → `op read` CLI → manual prompt.
 - Logging comes from `logger_config.setup_logging`; pass `use_rich=False` for plain output or a `log_file` path to persist logs.
 - All exports land under `output/`, named with `default_output_path()` which strips leading zeros for cross-platform friendly filenames.
@@ -193,8 +223,8 @@ disk.
 | Option | Description | Default |
 | --- | --- | --- |
 | `--api-key` | ClickUp API key | From environment or 1Password |
-| `--workspace` | Workspace name | `KMS` |
-| `--space` | Space name | `Kikkoman` |
+| `--workspace` | Workspace name | `CLICKUP_WORKSPACE_NAME` env var (else prompted) |
+| `--space` | Space name | `CLICKUP_SPACE_NAME` env var (else prompted) |
 | `--output` | Output file path | Auto-generated timestamp |
 | `--output-format` | Export format: `Markdown` or `HTML` | Prompted if not specified, defaults to `Markdown` |
 | `--include-completed` | Include completed/archived tasks | `False` |

--- a/ai_summary.py
+++ b/ai_summary.py
@@ -4,16 +4,26 @@
 AI Integration Module for ClickUp Task Extractor
 
 Contains:
-- AI summary generation using Google Gemini Flash-Latest API
+- AI summary generation using the Google Gemini API
 - Rate limiting and retry logic
 - Progress bar functionality for wait times
 """
 
+import os
 import time
 from typing import Callable, Mapping, Sequence, TypeAlias
 
-# Use Gemini Flash-Lite-Latest for AI summaries (paid tier)
-GEMINI_MODEL = "gemini-flash-lite-latest"
+# Gemini model used for AI summaries.
+#
+# Must be a published Google model id (see
+# https://ai.google.dev/gemini-api/docs/models). The previous value
+# "gemini-flash-lite-latest" was not a real model id and returned an
+# invalid-model error at runtime. "gemini-2.5-flash-lite" is the GA,
+# cost-efficient Flash-Lite tier documented in the README.
+#
+# Overridable via the GEMINI_MODEL environment variable so the model can be
+# bumped without a code change.
+GEMINI_MODEL = os.environ.get("GEMINI_MODEL", "gemini-2.5-flash-lite")
 
 # Rich console imports - create singleton instance with proper encoding for Windows
 try:

--- a/auth.py
+++ b/auth.py
@@ -210,7 +210,7 @@ def load_secret_with_fallback(secret_reference: str, secret_name: str) -> Secret
 
     Args:
         secret_reference: The 1Password secret reference for vault-based lookups
-                         (e.g., 'op://Home Server/ClickUp personal API token/credential')
+                         (e.g., 'op://<vault>/<item>/credential')
         secret_name: Human-readable name for the secret (for error messages)
 
     Returns:
@@ -415,7 +415,7 @@ def get_secret_from_1password(
     Retrieve a secret from 1Password using the SDK.
 
     Args:
-        secret_reference: The 1Password secret reference (e.g., "op://Home Server/ClickUp personal API token/credential")
+        secret_reference: The 1Password secret reference (e.g., "op://<vault>/<item>/credential")
         secret_type: Description of the secret type for error messages (default: "API key")
 
     Returns:
@@ -477,7 +477,7 @@ def get_api_key_from_1password(secret_reference: str) -> SecretValue:
     Retrieve ClickUp API key from 1Password using the SDK.
 
     Args:
-        secret_reference: The 1Password secret reference (e.g., "op://Home Server/ClickUp personal API token/credential")
+        secret_reference: The 1Password secret reference (e.g., "op://<vault>/<item>/credential")
 
     Returns:
         The API key string if successful, None if failed
@@ -493,7 +493,7 @@ def get_gemini_api_key_from_1password(secret_reference: str) -> SecretValue:
     Retrieve Gemini API key from 1Password using the SDK.
 
     Args:
-        secret_reference: The 1Password secret reference (e.g., "op://Home Server/nftoo3gsi3wpx7z5bdmcsvr7p4/credential")
+        secret_reference: The 1Password secret reference (e.g., "op://<vault>/<item>/credential")
 
     Returns:
         The Gemini API key string if successful, None if failed
@@ -510,5 +510,12 @@ def load_gemini_api_key_from_environment():
     Helper to load Gemini API key from 1Password Environment.
     Uses load_secret_with_fallback which checks OP_ENVIRONMENT_ID automatically.
     """
-    gemini_secret_reference = "op://Home Server/nftoo3gsi3wpx7z5bdmcsvr7p4/credential"
+    # Read the secret reference from configuration (GEMINI_API_SECRET_REFERENCE
+    # env var) rather than hardcoding a personal 1Password path. Imported locally
+    # to avoid any import-order coupling with the config module.
+    from config import GEMINI_API_SECRET_REFERENCE
+
+    gemini_secret_reference = GEMINI_API_SECRET_REFERENCE
+    if not gemini_secret_reference:
+        return None
     return load_secret_with_fallback(gemini_secret_reference, "Gemini API key")

--- a/config.py
+++ b/config.py
@@ -9,6 +9,7 @@ Contains:
 - Date/time formatting constants and utilities
 """
 
+import os
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from typing import Any
@@ -51,8 +52,37 @@ PRIORITY_ORDER = {
 }
 
 
-# Default ClickUp AI summary custom field identifier ("Summary")
-CLICKUP_AI_SUMMARY_FIELD_ID = "d7426f47-27f0-494b-b3a2-7d254132ee1a"
+# Default ClickUp AI summary custom field identifier ("Summary"), overridable
+# via the CLICKUP_AI_SUMMARY_FIELD_ID environment variable.
+CLICKUP_AI_SUMMARY_FIELD_ID = os.environ.get(
+    "CLICKUP_AI_SUMMARY_FIELD_ID", "d7426f47-27f0-494b-b3a2-7d254132ee1a"
+)
+
+
+# ---------------------------------------------------------------------------
+# Account-specific configuration.
+#
+# These values were previously hardcoded as personal defaults in source
+# (a 1Password vault path, a 1Password item id, a ClickUp team id, and the
+# workspace/space names). Hardcoding them exposed internal account structure
+# and made the tool single-tenant. They now read from environment variables
+# with non-personal defaults (empty strings), so anyone can configure the tool
+# for their own account — typically via a local .env file (see .env.example).
+# The owner's previous values can be restored by exporting these variables.
+# ---------------------------------------------------------------------------
+
+# 1Password secret references (op:// URIs) for the API keys. Empty by default;
+# when unset, main.py skips the 1Password lookup and falls back to the
+# CLICKUP_API_KEY / --api-key paths (and a manual prompt) instead.
+CLICKUP_API_SECRET_REFERENCE = os.environ.get("CLICKUP_API_SECRET_REFERENCE", "")
+GEMINI_API_SECRET_REFERENCE = os.environ.get("GEMINI_API_SECRET_REFERENCE", "")
+
+# ClickUp workspace/space names and team id. The extractor resolves the team
+# from the workspace name via the API first, falling back to CLICKUP_TEAM_ID /
+# this team id, then prompting interactively — so empty defaults are safe.
+DEFAULT_WORKSPACE_NAME = os.environ.get("CLICKUP_WORKSPACE_NAME", "")
+DEFAULT_SPACE_NAME = os.environ.get("CLICKUP_SPACE_NAME", "")
+DEFAULT_TEAM_ID = os.environ.get("CLICKUP_TEAM_ID", "")
 
 
 class OutputFormat(Enum):
@@ -289,15 +319,15 @@ class ClickUpConfig:
         ...     api_key="pk_123456789",
         ...     workspace_name="My Workspace",
         ...     space_name="Development",
-        ...     team_id="9014534294"
+        ...     team_id="1234567"
         ... )
     """
 
     api_key: str
-    workspace_name: str = "KMS"
-    space_name: str = "Kikkoman"
+    workspace_name: str = DEFAULT_WORKSPACE_NAME
+    space_name: str = DEFAULT_SPACE_NAME
     list_name: str | None = None
-    team_id: str = "9014534294"
+    team_id: str = DEFAULT_TEAM_ID
     output_path: str = field(default_factory=default_output_path)
     include_completed: bool = False
     date_filter: DateFilter = DateFilter.ALL_OPEN

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -29,6 +29,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Clarified the supported account selection flow for DesktopAuth and service-account auth.
 - Enabled executable workflows with `OP_ENVIRONMENT_ID` by reading Environment variables through 1Password CLI.
 
+### Security
+
+- Disabled `show_locals` in the Rich traceback handler (`logger_config.py`) so unhandled exceptions no longer render local variable contents — a stack frame could hold an API key or other secret, which `show_locals=True` would have printed to the console/logs (#105).
+
 ## [1.04] - 2026-04-07
 
 ### Fixed

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Removed the broken legacy vault-only fallback for Environment-based authentication.
 - Clarified the supported account selection flow for DesktopAuth and service-account auth.
 - Enabled executable workflows with `OP_ENVIRONMENT_ID` by reading Environment variables through 1Password CLI.
+- Corrected the Gemini model identifier from the invalid `gemini-flash-lite-latest` to the published `gemini-2.5-flash-lite` in `ai_summary.py` and `eta_calculator.py`; the value is now overridable via the `GEMINI_MODEL` environment variable. Added smoke tests that reject malformed model ids and the known-bad value (#109).
 
 ### Security
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated 1Password authentication to use 1Password Environment loading through the Python SDK for `OP_ENVIRONMENT_ID`.
 - Documented the Environment-based flow in the README and setup guidance.
 - Added 1Password CLI Environment fallback using `op environment read <environment_id>` when SDK auth is unavailable.
+- Moved committed personal identifiers (1Password vault paths/item IDs, ClickUp team ID, and the workspace/space names) out of source into environment variables with non-personal (empty) defaults: `CLICKUP_API_SECRET_REFERENCE`, `GEMINI_API_SECRET_REFERENCE`, `CLICKUP_WORKSPACE_NAME`, `CLICKUP_SPACE_NAME`, `CLICKUP_TEAM_ID`, and `CLICKUP_AI_SUMMARY_FIELD_ID`. When a `*_SECRET_REFERENCE` is unset, `main.py` skips the 1Password lookup and falls back to env var / CLI flag / prompt. Added `.env.example` and a README **Configuration** section documenting the variables (#106).
 
 ### Fixed
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Pinned dependencies with compatible-release (`~=`) specifiers instead of `>=` lower bounds, so breaking major releases of `requests`, `google-genai`, `rich`, or `gspread` cannot be picked up silently. `onepassword-sdk` (still a 0.x beta) is pinned exactly. Use `requirements.lock` for a byte-for-byte reproducible environment (#108).
+- Made `kfj_task_extractor.py` configurable instead of single-tenant: the ClickUp list ID, Google Sheet ID, 1Password secret references, and 1Password account name/URL now read from `KFJ_*` environment variables with non-personal (empty) defaults. `--list-id`/`--sheet-id` still override, and `main()` now errors clearly when no list/sheet is configured. Added `.env.kfj.example` and a README **Configuration** subsection documenting every variable and where to find the IDs (#110).
 
 - Updated 1Password authentication to use 1Password Environment loading through the Python SDK for `OP_ENVIRONMENT_ID`.
 - Documented the Environment-based flow in the README and setup guidance.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -16,8 +16,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Reuses existing components (`ClickUpAPIClient`, `load_secret_with_fallback`, `TaskRecord`, `sort_tasks_by_priority_and_eta`, `LocationMapper`) without modifying the main extraction workflow.
   - Supports `--dry-run`, `--list-id`, `--sheet-id`, and `--date M/D/YY` overrides.
 - Added `gspread>=6.1.0` dependency for the Google Sheets integration.
+- Added `requirements.lock` — a fully-resolved lock file (`pip freeze` output) for reproducible installs of the exact transitive versions the project is tested against (#108).
 
 ### Changed
+
+- Pinned dependencies with compatible-release (`~=`) specifiers instead of `>=` lower bounds, so breaking major releases of `requests`, `google-genai`, `rich`, or `gspread` cannot be picked up silently. `onepassword-sdk` (still a 0.x beta) is pinned exactly. Use `requirements.lock` for a byte-for-byte reproducible environment (#108).
 
 - Updated 1Password authentication to use 1Password Environment loading through the Python SDK for `OP_ENVIRONMENT_ID`.
 - Documented the Environment-based flow in the README and setup guidance.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Clarified the supported account selection flow for DesktopAuth and service-account auth.
 - Enabled executable workflows with `OP_ENVIRONMENT_ID` by reading Environment variables through 1Password CLI.
 - Corrected the Gemini model identifier from the invalid `gemini-flash-lite-latest` to the published `gemini-2.5-flash-lite` in `ai_summary.py` and `eta_calculator.py`; the value is now overridable via the `GEMINI_MODEL` environment variable. Added smoke tests that reject malformed model ids and the known-bad value (#109).
+- Guarded module-level side effects in `main.py` and `kfj_task_extractor.py` behind `if __name__ == "__main__"`. The virtualenv re-exec, UTF-8 stdio reconfiguration, and `setup_logging()` no longer run at import time, so the modules can be imported by tests and tooling without triggering a process re-exec, mutating `sys.stdout`/`sys.stderr`, or reconfiguring the shared logger (#107).
 
 ### Security
 

--- a/eta_calculator.py
+++ b/eta_calculator.py
@@ -9,6 +9,7 @@ Contains:
 - Fallback mechanisms for when AI is unavailable
 """
 
+import os
 from datetime import datetime, timedelta
 from typing import TypeAlias
 
@@ -62,8 +63,11 @@ except ImportError:
 # Type aliases
 ETAResult: TypeAlias = str
 
-# AI Model configuration
-GEMINI_MODEL = "gemini-flash-lite-latest"
+# AI Model configuration.
+# Must be a published Google model id. The previous "gemini-flash-lite-latest"
+# was not a real model id; "gemini-2.5-flash-lite" is the GA Flash-Lite tier.
+# Overridable via the GEMINI_MODEL environment variable.
+GEMINI_MODEL = os.environ.get("GEMINI_MODEL", "gemini-2.5-flash-lite")
 
 # Priority-based default ETA offsets (in days)
 PRIORITY_ETA_DAYS = {

--- a/kfj_task_extractor.py
+++ b/kfj_task_extractor.py
@@ -94,30 +94,41 @@ from mappers import LocationMapper
 console = Console()
 logger = get_logger(__name__)
 
-DEFAULT_LIST_ID = "901413205844"  # ClickUp list "KFI Jefferson"
-DEFAULT_SHEET_ID = "13plvMvZDvF5qIEhdDzJIhgoM1TdNoe9KZ1673AiAJ50"
-TAB_PREFIX = "KFI Jefferson current tasks"
+# ---------------------------------------------------------------------------
+# Configuration.
+#
+# The values below were previously hardcoded as personal defaults (a ClickUp
+# list id, a Google Sheet id, 1Password vault/item references, and a 1Password
+# account name), which made this script single-tenant. They now read from
+# environment variables with non-personal (empty) defaults so the script can be
+# pointed at any list/sheet/account — typically via a local .env.kfj file (see
+# .env.kfj.example). The list/sheet ids can also be passed on the CLI with
+# --list-id / --sheet-id, which take precedence over these defaults.
+# ---------------------------------------------------------------------------
+
+# ClickUp list id and Google Sheets workbook id (empty by default).
+DEFAULT_LIST_ID = os.environ.get("KFJ_CLICKUP_LIST_ID", "")
+DEFAULT_SHEET_ID = os.environ.get("KFJ_GOOGLE_SHEET_ID", "")
+
+TAB_PREFIX = os.environ.get("KFJ_TAB_PREFIX", "KFI Jefferson current tasks")
 HEADER = ["Task", "Company", "Branch", "Priority", "Status", "ETA"]
-FALLBACK_BRANCH = "KFJ (213)"
+FALLBACK_BRANCH = os.environ.get("KFJ_FALLBACK_BRANCH", "")
 PRIORITY_MAP = {1: "Low", 2: "Normal", 3: "High", 4: "Urgent"}
 SCOPES = ["https://www.googleapis.com/auth/spreadsheets"]
-# Both secrets live in the "Dev" vault (ksvblaaxovsjqoanl4dzo2apdu) of the
-# personal 1Password account, so a single authentication covers both.
-# References use vault/item IDs (not names): the 1Password desktop SDK
-# integration only matches vaults by ID, IDs survive renames, and they work
-# everywhere else too (op CLI, op run, service-token SDK).
-# Item "ClickUp personal API token":
-CLICKUP_SECRET_REFERENCE = (
-    "op://ksvblaaxovsjqoanl4dzo2apdu/ClickUp personal API token/credential"
-)
-# Item "GC SDK service account":
-GOOGLE_SA_SECRET_REFERENCE = (
-    "op://ksvblaaxovsjqoanl4dzo2apdu/q6cioe2ngge2k2mpf2ojps77la/credential"
-)
-# DesktopAuth expects the account *display name* as shown in the 1Password
-# app; the op CLI expects the account URL.
-PERSONAL_ACCOUNT_NAME = "Maffiola Family"
-PERSONAL_ACCOUNT_URL = "my.1password.com"
+
+# 1Password secret references (op:// URIs) for the ClickUp API key and the
+# Google service-account JSON. Both default to empty; when unset, the resolver
+# falls back to the KFJ_*/standard environment variables (see _resolve_secret).
+# References may use vault/item IDs or names; IDs survive renames and work with
+# the desktop SDK, op CLI, op run, and service-token SDK.
+CLICKUP_SECRET_REFERENCE = os.environ.get("KFJ_CLICKUP_SECRET_REFERENCE", "")
+# Service-account JSON item:
+GOOGLE_SA_SECRET_REFERENCE = os.environ.get("KFJ_GOOGLE_SA_SECRET_REFERENCE", "")
+
+# 1Password account selectors. DesktopAuth expects the account *display name*
+# as shown in the 1Password app; the op CLI expects the account URL.
+PERSONAL_ACCOUNT_NAME = os.environ.get("KFJ_OP_ACCOUNT_NAME", "")
+PERSONAL_ACCOUNT_URL = os.environ.get("KFJ_OP_ACCOUNT_URL", "my.1password.com")
 
 
 def read_secret_via_op_cli(
@@ -173,8 +184,16 @@ def _resolve_secret(
     if value:
         logger.debug(f"Using {secret_name} from environment variable {env_var}")
         return value
+    # Without a configured 1Password reference, skip the 1Password lookups and
+    # rely on the environment variable above (e.g. injected via `op run`).
+    if not secret_reference:
+        logger.debug(
+            f"No 1Password reference configured for {secret_name}; "
+            f"set {env_var} or KFJ_*_SECRET_REFERENCE to enable 1Password lookup."
+        )
+        return None
     value = resolve_secret_with_desktop_sdk(
-        secret_reference, secret_name, [sdk_account_name]
+        secret_reference, secret_name, [sdk_account_name] if sdk_account_name else []
     )
     if value:
         return value
@@ -396,12 +415,14 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--list-id",
         default=DEFAULT_LIST_ID,
-        help=f"ClickUp list ID to extract from (default: {DEFAULT_LIST_ID})",
+        help="ClickUp list ID to extract from "
+        "(default: KFJ_CLICKUP_LIST_ID env var)",
     )
     parser.add_argument(
         "--sheet-id",
         default=DEFAULT_SHEET_ID,
-        help="Google Sheets workbook ID to write to",
+        help="Google Sheets workbook ID to write to "
+        "(default: KFJ_GOOGLE_SHEET_ID env var)",
     )
     parser.add_argument(
         "--dry-run",
@@ -421,6 +442,21 @@ def main() -> int:
     """Run the extraction and sheet update. Returns process exit code."""
     setup_logging(logging.INFO)
     args = parse_args()
+
+    # The list/sheet ids are no longer hardcoded; require them via --list-id /
+    # --sheet-id or the KFJ_CLICKUP_LIST_ID / KFJ_GOOGLE_SHEET_ID env vars.
+    if not args.list_id:
+        console.print(
+            "[red]No ClickUp list ID configured. Pass --list-id or set "
+            "KFJ_CLICKUP_LIST_ID (see .env.kfj.example).[/red]"
+        )
+        return 1
+    if not args.sheet_id and not args.dry_run:
+        console.print(
+            "[red]No Google Sheet ID configured. Pass --sheet-id or set "
+            "KFJ_GOOGLE_SHEET_ID (see .env.kfj.example), or use --dry-run.[/red]"
+        )
+        return 1
 
     if args.date:
         try:

--- a/kfj_task_extractor.py
+++ b/kfj_task_extractor.py
@@ -42,28 +42,40 @@ import subprocess
 import sys
 from datetime import date, datetime, timezone
 
-# Re-launch inside the project venv when available (same convenience pattern
-# as main.py) so dependencies resolve regardless of the invoking interpreter.
-script_dir = os.path.dirname(os.path.abspath(__file__))
-if os.name == "nt":
-    venv_python = os.path.join(script_dir, ".venv", "Scripts", "python.exe")
-else:
-    venv_python = os.path.join(script_dir, ".venv", "bin", "python")
+def _reexec_in_venv() -> None:
+    """Re-launch inside the project venv when available (same convenience
+    pattern as main.py) so dependencies resolve regardless of the invoking
+    interpreter.
 
-if not sys.executable.startswith(os.path.join(script_dir, ".venv")) and os.path.exists(
-    venv_python
-):
-    print(f"Switching from {sys.executable} to virtual environment: {venv_python}")
-    sys.exit(subprocess.call([venv_python] + sys.argv))
+    No-op when already running from the venv or when the venv does not exist.
+    Called only from the ``__main__`` guard so importing this module never
+    triggers a process re-exec or re-exec loop.
+    """
+    script_dir = os.path.dirname(os.path.abspath(__file__))
+    if os.name == "nt":
+        venv_python = os.path.join(script_dir, ".venv", "Scripts", "python.exe")
+    else:
+        venv_python = os.path.join(script_dir, ".venv", "bin", "python")
 
-# Force UTF-8 output so Unicode survives redirected/cp1252 consoles
-# (e.g. when run under `op run` on Windows)
-for stream in (sys.stdout, sys.stderr):
-    if hasattr(stream, "reconfigure") and (stream.encoding or "").lower() not in (
-        "utf-8",
-        "utf8",
-    ):
-        stream.reconfigure(encoding="utf-8")
+    if not sys.executable.startswith(
+        os.path.join(script_dir, ".venv")
+    ) and os.path.exists(venv_python):
+        print(f"Switching from {sys.executable} to virtual environment: {venv_python}")
+        sys.exit(subprocess.call([venv_python] + sys.argv))
+
+
+def _configure_stdio_encoding() -> None:
+    """Force UTF-8 output so Unicode survives redirected/cp1252 consoles
+    (e.g. when run under ``op run`` on Windows). Mutates sys.stdout/stderr,
+    so it is only invoked from the ``__main__`` guard.
+    """
+    for stream in (sys.stdout, sys.stderr):
+        if hasattr(stream, "reconfigure") and (stream.encoding or "").lower() not in (
+            "utf-8",
+            "utf8",
+        ):
+            stream.reconfigure(encoding="utf-8")
+
 
 try:
     from rich.console import Console
@@ -492,4 +504,9 @@ def main() -> int:
 
 
 if __name__ == "__main__":
+    # Side effects that must only run when executed as a script, never on import:
+    #   1. Re-exec under the project venv if not already running from it.
+    #   2. Reconfigure stdio to UTF-8 (mutates sys.stdout/sys.stderr).
+    _reexec_in_venv()
+    _configure_stdio_encoding()
     sys.exit(main())

--- a/logger_config.py
+++ b/logger_config.py
@@ -21,8 +21,11 @@ try:
 
     RICH_AVAILABLE = True
 
-    # Install rich tracebacks for beautiful error displays
-    install(show_locals=True, suppress=["logging"])
+    # Install rich tracebacks for beautiful error displays.
+    # show_locals is kept False so unhandled exceptions never render the
+    # contents of local variables — a stack frame may hold an API key or
+    # other secret, and show_locals=True would leak it to the console/logs.
+    install(show_locals=False, suppress=["logging"])
 except ImportError:
     RICH_AVAILABLE = False
     RichHandler = None

--- a/main.py
+++ b/main.py
@@ -39,6 +39,10 @@ from config import (
     AISource,
     format_datetime,
     CLICKUP_AI_SUMMARY_FIELD_ID,
+    CLICKUP_API_SECRET_REFERENCE,
+    GEMINI_API_SECRET_REFERENCE,
+    DEFAULT_WORKSPACE_NAME,
+    DEFAULT_SPACE_NAME,
 )
 from logger_config import setup_logging
 from mappers import get_choice_input, get_yes_no_input
@@ -183,7 +187,7 @@ def main():
     )
 
     parser = argparse.ArgumentParser(
-        description=f"ClickUp Task Extractor v{__version__} - {__description__}\n\nExtract and export ClickUp tasks to Markdown (default) or HTML. Default workspace: KMS.\nAPI keys can be provided via: 1Password Environment (OP_ENVIRONMENT_ID), environment variables (CLICKUP_API_KEY), or command-line arguments.\n\n1Password Environment Setup: Developer > View Environments > Create new > Add CLICKUP_API_KEY variable > Copy Environment ID > export OP_ENVIRONMENT_ID=<id>",
+        description=f"ClickUp Task Extractor v{__version__} - {__description__}\n\nExtract and export ClickUp tasks to Markdown (default) or HTML. The workspace and space are configured via --workspace/--space or the CLICKUP_WORKSPACE_NAME/CLICKUP_SPACE_NAME environment variables.\nAPI keys can be provided via: 1Password Environment (OP_ENVIRONMENT_ID), environment variables (CLICKUP_API_KEY), or command-line arguments.\n\n1Password Environment Setup: Developer > View Environments > Create new > Add CLICKUP_API_KEY variable > Copy Environment ID > export OP_ENVIRONMENT_ID=<id>",
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
     parser.add_argument(
@@ -201,8 +205,16 @@ def main():
         default=os.environ.get("CLICKUP_API_KEY"),
         help="ClickUp API Key (or set CLICKUP_API_KEY env var). Falls back to 1Password Environment or 1Password SDK (requires OP_SERVICE_ACCOUNT_TOKEN).",
     )
-    parser.add_argument("--workspace", type=str, help="Workspace name (default: KMS)")
-    parser.add_argument("--space", type=str, help="Space name (default: Kikkoman)")
+    parser.add_argument(
+        "--workspace",
+        type=str,
+        help="Workspace name (overrides the CLICKUP_WORKSPACE_NAME env var)",
+    )
+    parser.add_argument(
+        "--space",
+        type=str,
+        help="Space name (overrides the CLICKUP_SPACE_NAME env var)",
+    )
     parser.add_argument(
         "--list", type=str, help="Optional list name to extract from within the space"
     )
@@ -252,7 +264,9 @@ def main():
     )
     args = parser.parse_args()
 
-    # 1Password reference for API key: "op://Home Server/ClickUp personal API token/credential"
+    # The 1Password secret reference for the API key is configured via the
+    # CLICKUP_API_SECRET_REFERENCE environment variable (config module). It is
+    # empty by default so no personal vault path is baked into source.
     api_key = args.api_key or os.environ.get("CLICKUP_API_KEY")
 
     if not api_key:
@@ -284,8 +298,9 @@ def main():
                 style="yellow",
             )
         )
-        secret_reference = "op://Home Server/ClickUp personal API token/credential"
-        api_key = load_secret_with_fallback(secret_reference, "ClickUp API key")
+        secret_reference = CLICKUP_API_SECRET_REFERENCE
+        if secret_reference:
+            api_key = load_secret_with_fallback(secret_reference, "ClickUp API key")
         if not api_key:
             if is_frozen:
                 console.print(
@@ -330,13 +345,14 @@ def main():
         if gemini_api_key:
             return True  # Already have the key
 
-        # Try to get Gemini API key from 1Password with fallback
-        gemini_secret_reference = (
-            "op://Home Server/nftoo3gsi3wpx7z5bdmcsvr7p4/credential"
-        )
-        gemini_api_key = load_secret_with_fallback(
-            gemini_secret_reference, "Gemini API key"
-        )
+        # Try to get Gemini API key from 1Password with fallback. The secret
+        # reference comes from GEMINI_API_SECRET_REFERENCE (config module) and is
+        # empty by default so no personal vault path is baked into source.
+        gemini_secret_reference = GEMINI_API_SECRET_REFERENCE
+        if gemini_secret_reference:
+            gemini_api_key = load_secret_with_fallback(
+                gemini_secret_reference, "Gemini API key"
+            )
         if gemini_api_key:
             return True
         else:
@@ -492,8 +508,8 @@ def main():
 
     config = ClickUpConfig(
         api_key=api_key,
-        workspace_name=args.workspace or "KMS",
-        space_name=args.space or "Kikkoman",
+        workspace_name=args.workspace or DEFAULT_WORKSPACE_NAME,
+        space_name=args.space or DEFAULT_SPACE_NAME,
         list_name=args.list,
         output_path=args.output
         or f"output/WeeklyTaskList_{format_datetime(datetime.now(), TIMESTAMP_FORMAT)}.md",

--- a/main.py
+++ b/main.py
@@ -91,29 +91,39 @@ def _configure_stdio_encoding() -> None:
                 continue
 
 
-_configure_stdio_encoding()
-
-# Initialize Rich console with proper encoding for cross-platform compatibility
-# This ensures proper rendering on Windows, macOS, and Linux
+# Initialize Rich console with proper encoding for cross-platform compatibility.
+# This ensures proper rendering on Windows, macOS, and Linux. Constructing a
+# Console is a side-effect-free object instantiation (no I/O, no subprocess),
+# so it is safe to do at import time and lets the module's helper functions
+# reference `console` as a module global.
 console = Console(force_terminal=None, legacy_windows=False)
 
-# Setup enhanced logging with Rich
-logger = setup_logging(logging.INFO, use_rich=True)
+# Logging is configured lazily in main() rather than at import time, because
+# setup_logging() mutates the shared "clickup_extractor" logger (clearing and
+# re-adding handlers) and may open a file handler — side effects that should
+# not fire merely from importing this module (e.g. under test/tooling).
+logger = None
 
-# Ensure we're using the virtual environment
-script_dir = os.path.dirname(os.path.abspath(__file__))
-if os.name == "nt":
-    venv_python = os.path.join(script_dir, ".venv", "Scripts", "python.exe")
-else:
-    venv_python = os.path.join(script_dir, ".venv", "bin", "python")
 
-# If we're not running from the venv and the venv exists, restart with the venv Python
-if not sys.executable.startswith(os.path.join(script_dir, ".venv")) and os.path.exists(
-    venv_python
-):
-    print(f"Switching from {sys.executable} to virtual environment: {venv_python}")
-    # Re-execute the script with the virtual environment Python
-    sys.exit(subprocess.call([venv_python] + sys.argv))
+def _reexec_in_venv() -> None:
+    """Re-launch this script under the project's virtualenv interpreter.
+
+    No-op when already running from the venv or when the venv does not exist.
+    Called only from the ``__main__`` guard so that importing this module
+    (for tests/tooling) never triggers a process re-exec or re-exec loop.
+    """
+    script_dir = os.path.dirname(os.path.abspath(__file__))
+    if os.name == "nt":
+        venv_python = os.path.join(script_dir, ".venv", "Scripts", "python.exe")
+    else:
+        venv_python = os.path.join(script_dir, ".venv", "bin", "python")
+
+    if not sys.executable.startswith(
+        os.path.join(script_dir, ".venv")
+    ) and os.path.exists(venv_python):
+        print(f"Switching from {sys.executable} to virtual environment: {venv_python}")
+        # Re-execute the script with the virtual environment Python
+        sys.exit(subprocess.call([venv_python] + sys.argv))
 
 
 def main():
@@ -135,6 +145,11 @@ def main():
     - Add variable: CLICKUP_API_KEY = your ClickUp API key
     - Copy Environment ID and set: export OP_ENVIRONMENT_ID=<environment_id>
     """
+    global logger
+    # Configure logging on first entry into main() rather than at import time.
+    if logger is None:
+        logger = setup_logging(logging.INFO, use_rich=True)
+
     try:
         _ClickUpAPIClient, _ClickUpTaskExtractor = _load_runtime_dependencies()
     except (KeyboardInterrupt, ImportError):
@@ -534,4 +549,9 @@ def main():
 
 
 if __name__ == "__main__":
+    # Side effects that must only run when executed as a script, never on import:
+    #   1. Reconfigure stdio to UTF-8 (mutates sys.stdout/sys.stderr).
+    #   2. Re-exec under the project venv if not already running from it.
+    _configure_stdio_encoding()
+    _reexec_in_venv()
     main()

--- a/requirements.lock
+++ b/requirements.lock
@@ -1,0 +1,43 @@
+# Fully-resolved dependency lock for ClickUp Task Extractor.
+#
+# Generated with: pip freeze (from a clean venv after 'pip install -r requirements.txt').
+# Provides a reproducible install of the exact transitive versions this
+# project was tested against. For a byte-for-byte reproducible environment:
+#     pip install -r requirements.lock
+# For normal development use requirements.txt (compatible-release pins).
+# Regenerate after changing requirements.txt.
+#
+annotated-types==0.7.0
+anyio==4.14.0
+certifi==2026.5.20
+cffi==2.0.0
+charset-normalizer==3.4.7
+cryptography==49.0.0
+distro==1.9.0
+google-auth==2.55.0
+google-auth-oauthlib==1.4.0
+google-genai==2.8.0
+gspread==6.2.1
+h11==0.16.0
+httpcore==1.0.9
+httpx==0.28.1
+idna==3.18
+markdown-it-py==4.2.0
+mdurl==0.1.2
+oauthlib==3.3.1
+onepassword-sdk==0.4.1b1
+pyasn1==0.6.3
+pyasn1_modules==0.4.2
+pycparser==3.0
+pydantic==2.13.4
+pydantic_core==2.46.4
+Pygments==2.20.0
+requests==2.34.2
+requests-oauthlib==2.0.0
+rich==15.0.0
+sniffio==1.3.1
+tenacity==9.1.4
+typing-inspection==0.4.2
+typing_extensions==4.15.0
+urllib3==2.7.0
+websockets==16.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,18 @@
-requests>=2.25.0
-onepassword-sdk>=0.4.1b1
-google-genai>=1.0.0  # Google Gemini API SDK
-rich>=14.0.0
-gspread>=6.1.0  # Google Sheets client (kfj_task_extractor.py)
+# Dependency pins for ClickUp Task Extractor.
+#
+# Uses compatible-release (`~=`) pins so patch/minor updates are allowed but a
+# breaking MAJOR release cannot be picked up silently. The versions below are
+# the ones this project is tested against (see docs/CHANGELOG.md). Bump the
+# floor deliberately after testing a newer release.
+#
+# `~=X.Y` means ">=X.Y, ==X.*" (any X.Y or newer within the same major).
 
+requests~=2.32          # HTTP client for the ClickUp API
+google-genai~=2.8       # Google Gemini API SDK
+rich~=15.0              # Console UI / logging
+gspread~=6.2            # Google Sheets client (kfj_task_extractor.py)
+
+# 1Password SDK is still a beta (0.x) release and no stable version above 0.4.0
+# is published, so it is pinned exactly rather than with `~=` (a 0.x `~=` pin is
+# effectively an exact pin anyway). Revisit when a stable >=0.4.1 ships.
+onepassword-sdk==0.4.1b1

--- a/tests/test_ai_summary.py
+++ b/tests/test_ai_summary.py
@@ -1,6 +1,35 @@
+import re
 import unittest
 
+import ai_summary
+import eta_calculator
 from ai_summary import _normalize_field_entries, get_ai_summary
+
+
+# Published Google Gemini model ids follow this shape, e.g.
+# "gemini-2.5-flash-lite", "gemini-2.5-pro", "gemini-2.0-flash".
+# See https://ai.google.dev/gemini-api/docs/models
+_VALID_GEMINI_MODEL_RE = re.compile(r"^gemini-\d+(?:\.\d+)?-[a-z0-9-]+$")
+
+# Known-invalid id that previously shipped and returned an invalid-model error
+# at runtime. Guarding against it explicitly prevents a regression.
+_KNOWN_BAD_MODEL = "gemini-flash-lite-latest"
+
+
+class GeminiModelSmokeTests(unittest.TestCase):
+    """Catch model-name regressions without making a live API call (issue #109)."""
+
+    def test_ai_summary_model_id_is_well_formed(self) -> None:
+        self.assertNotEqual(ai_summary.GEMINI_MODEL, _KNOWN_BAD_MODEL)
+        self.assertRegex(ai_summary.GEMINI_MODEL, _VALID_GEMINI_MODEL_RE)
+
+    def test_eta_calculator_model_id_is_well_formed(self) -> None:
+        self.assertNotEqual(eta_calculator.GEMINI_MODEL, _KNOWN_BAD_MODEL)
+        self.assertRegex(eta_calculator.GEMINI_MODEL, _VALID_GEMINI_MODEL_RE)
+
+    def test_model_ids_match_across_modules(self) -> None:
+        # Both modules drive the same Gemini integration; their defaults must agree.
+        self.assertEqual(ai_summary.GEMINI_MODEL, eta_calculator.GEMINI_MODEL)
 
 
 class NormalizeFieldEntriesTests(unittest.TestCase):

--- a/tests/test_ai_summary_success.py
+++ b/tests/test_ai_summary_success.py
@@ -402,7 +402,9 @@ class TestRateLimitingAndRetry(unittest.TestCase):
     @patch('ai_summary.GenerativeModel')
     @patch('ai_summary.configure')
     def test_uses_correct_model(self, mock_configure, mock_model_class, mock_types):
-        """Test uses correct Gemini model (gemini-flash-lite-latest)."""
+        """Test uses the configured Gemini model (ai_summary.GEMINI_MODEL)."""
+        import ai_summary
+
         mock_model = Mock()
         mock_response = Mock()
         mock_response.text = 'Summary'
@@ -412,8 +414,8 @@ class TestRateLimitingAndRetry(unittest.TestCase):
         field_entries = [('Name', 'Task')]
         get_ai_summary('Task', field_entries, 'api_key')
 
-        # Verify GenerativeModel was called with the correct model
-        mock_model_class.assert_called_once_with('gemini-flash-lite-latest')
+        # Verify GenerativeModel was called with the module's configured model id.
+        mock_model_class.assert_called_once_with(ai_summary.GEMINI_MODEL)
 
     @patch('ai_summary.types')
     @patch('ai_summary.GenerativeModel')

--- a/tests/test_extractor.py
+++ b/tests/test_extractor.py
@@ -394,6 +394,8 @@ class FetchProcessTasksTests(unittest.TestCase):
             config = ClickUpConfig(
                 api_key="dummy",
                 output_path=str(Path(tmpdir) / "out.md"),
+                workspace_name=workspace_name,
+                space_name=space_name,
                 team_id=team_id,
             )
             api_client = DummyAPIClient(responses)
@@ -459,6 +461,8 @@ class FetchProcessTasksTests(unittest.TestCase):
             config = ClickUpConfig(
                 api_key="dummy",
                 output_path=str(Path(tmpdir) / "out.md"),
+                workspace_name="KMS",
+                space_name="Kikkoman",
                 team_id="team1",
                 list_name="KFI Jefferson",
             )
@@ -531,6 +535,8 @@ class FetchProcessTasksTests(unittest.TestCase):
             config = ClickUpConfig(
                 api_key="dummy",
                 output_path=str(Path(tmpdir) / "out.md"),
+                workspace_name="KMS",
+                space_name="Kikkoman",
                 team_id="team1",
             )
             api_client = DummyAPIClient(responses)

--- a/tests/test_kfj_task_extractor.py
+++ b/tests/test_kfj_task_extractor.py
@@ -285,6 +285,10 @@ class TestCredentialResolution(unittest.TestCase):
         with mock.patch.dict(os.environ, {}, clear=True):
             with (
                 mock.patch(
+                    "kfj_task_extractor.CLICKUP_SECRET_REFERENCE",
+                    "op://vault/item/credential",
+                ),
+                mock.patch(
                     "kfj_task_extractor.resolve_secret_with_desktop_sdk",
                     return_value="pk_from_sdk",
                 ) as sdk,
@@ -299,6 +303,10 @@ class TestCredentialResolution(unittest.TestCase):
     def test_clickup_key_falls_back_when_sdk_fails(self):
         with mock.patch.dict(os.environ, {}, clear=True):
             with (
+                mock.patch(
+                    "kfj_task_extractor.CLICKUP_SECRET_REFERENCE",
+                    "op://vault/item/credential",
+                ),
                 mock.patch(
                     "kfj_task_extractor.resolve_secret_with_desktop_sdk",
                     return_value=None,
@@ -325,6 +333,10 @@ class TestCredentialResolution(unittest.TestCase):
         with mock.patch.dict(os.environ, {}, clear=True):
             with (
                 mock.patch(
+                    "kfj_task_extractor.GOOGLE_SA_SECRET_REFERENCE",
+                    "op://vault/item/credential",
+                ),
+                mock.patch(
                     "kfj_task_extractor.resolve_secret_with_desktop_sdk",
                     return_value='{"type": "service_account"}',
                 ) as sdk,
@@ -342,6 +354,10 @@ class TestCredentialResolution(unittest.TestCase):
         with mock.patch.dict(os.environ, {}, clear=True):
             with (
                 mock.patch(
+                    "kfj_task_extractor.GOOGLE_SA_SECRET_REFERENCE",
+                    "op://vault/item/credential",
+                ),
+                mock.patch(
                     "kfj_task_extractor.resolve_secret_with_desktop_sdk",
                     return_value=None,
                 ),
@@ -356,6 +372,25 @@ class TestCredentialResolution(unittest.TestCase):
             ):
                 self.assertIsNone(load_google_credentials_json())
                 op_cli.assert_called_once()
+
+    def test_clickup_key_skips_1password_when_reference_unset(self):
+        """With no env var and an empty secret reference, the 1Password chain is
+        skipped and resolution returns None (issue #110)."""
+        with mock.patch.dict(os.environ, {}, clear=True):
+            with (
+                mock.patch("kfj_task_extractor.CLICKUP_SECRET_REFERENCE", ""),
+                mock.patch(
+                    "kfj_task_extractor.resolve_secret_with_desktop_sdk",
+                    return_value="should_not_be_used",
+                ) as sdk,
+                mock.patch(
+                    "kfj_task_extractor.load_secret_with_fallback",
+                    return_value="should_not_be_used",
+                ) as fallback,
+            ):
+                self.assertIsNone(resolve_clickup_api_key())
+                sdk.assert_not_called()
+                fallback.assert_not_called()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Aggregated 2026 code-review fixes for manual review. Do not merge until reviewed.

Fixes #105
Fixes #106
Fixes #107
Fixes #108
Fixes #109
Fixes #110

## Issues addressed
- #105 (security) — Disabled `show_locals` in the Rich traceback handler so unhandled exceptions no longer leak API keys held in stack frames.
- #106 (bug) — Moved committed personal 1Password vault paths, ClickUp team ID, and workspace/space names out of source into `CLICKUP_*` env vars with non-personal defaults; added `.env.example` + README Configuration section.
- #107 (bug) — Guarded module-level side effects (venv re-exec, UTF-8 stdio reconfig, `setup_logging()`) behind `if __name__ == "__main__"` in `main.py` and `kfj_task_extractor.py`, so the modules import cleanly for tests/tooling.
- #108 (enhancement) — Pinned dependencies with compatible-release (`~=`) specifiers and added a fully-resolved `requirements.lock`; `onepassword-sdk` beta pinned exactly with a note to graduate off it.
- #109 (bug) — Replaced the invalid `gemini-flash-lite-latest` model id with the published `gemini-2.5-flash-lite` (env-overridable) in `ai_summary.py` and `eta_calculator.py`; added regression smoke tests.
- #110 (documentation) — De-hardcoded the kfj list/sheet/1Password identifiers into `KFJ_*` env vars and documented them via `.env.kfj.example` and an expanded README section.

## Testing
- Python deps installed successfully in a fresh venv (`requests`, `onepassword-sdk` 0.4.1b1, `google-genai`, `rich`, `gspread`) — full suite runnable here.
- Full `pytest` on the integrated `2026-review` branch: **6 failed / 266 passed**. All 6 failures are pre-existing and present on a pristine `main` checkout — 5 make real ClickUp API calls without a key (`test_main` x2, `test_interactive_ai_summary` x3) and 1 is a pre-existing test-isolation ordering case (`test_logger_config`). This review introduced **0 new failures** and **4 net-new passing tests** (3 Gemini model smoke tests, 1 kfj credential short-circuit test).
- The pinned `requirements.txt` was re-verified end-to-end in a clean venv.
- Each per-issue change was merged via its own reviewed squash PR: #111, #112, #113, #114, #115, #116.

## Notes for the reviewer
- #106 and #110 remove personal identifiers from the **working tree only** — git history still contains them (no history rewrite / force-push was performed, per the task constraints).
- `onepassword-sdk` remains a `0.4.1b1` beta pin (no stable >=0.4.1 published).