### PR TITLE
fix: guard against null type_config in LocationMapper call

### DIFF
--- a/extractor.py
+++ b/extractor.py
@@ -697,8 +697,8 @@ class ClickUpTaskExtractor:
             branch_field = cf.get("Branch")
             if branch_field:
                 val = branch_field.get("value")
-                type_config = branch_field.get("type_config", {})
-                options = type_config.get("options", [])
+                type_config = branch_field.get("type_config") or {}
+                options = type_config.get("options") or []
                 branch_value = LocationMapper.map_location(val, type_config, options)
 
             def extract_field_value(field: dict | None) -> str:


### PR DESCRIPTION
Fixes #124

## Changes

- `extractor.py`: replace `.get("type_config", {})` with `.get("type_config") or {}` and `.get("options", [])` with `.get("options") or []`

## Why

`dict.get(key, default)` only substitutes the default when the key is **absent**. If the ClickUp API explicitly returns `"type_config": null`, `.get()` returns `None`, and the subsequent `.get("options", [])` raises `AttributeError`. Using `or {}` handles both missing keys and explicit nulls.