### PR TITLE
feat: make ClickUpAPIClient request timeout configurable

### DIFF
--- a/api_client.py
+++ b/api_client.py
@@ -61,14 +61,18 @@ class ClickUpAPIClient:
         429,
     }  # Bad Gateway, Service Unavailable, Gateway Timeout, Rate Limit
 
-    def __init__(self, api_key: str) -> None:
+    DEFAULT_TIMEOUT = 30  # seconds
+
+    def __init__(self, api_key: str, timeout: int = DEFAULT_TIMEOUT) -> None:
         """
         Initialize the ClickUp API client.
 
         Args:
             api_key: ClickUp API key for authentication
+            timeout: Request timeout in seconds (default: 30)
         """
         self.headers = {"Authorization": api_key, "Content-Type": "application/json"}
+        self.timeout = timeout
 
     def _exponential_backoff_with_jitter(self, attempt: int) -> float:
         """
@@ -105,7 +109,7 @@ class ClickUpAPIClient:
 
         for attempt in range(self.MAX_RETRIES):
             try:
-                resp = requests.get(url, headers=self.headers, timeout=30)
+                resp = requests.get(url, headers=self.headers, timeout=self.timeout)
 
                 # Check if this is a retryable error
                 if (

--- a/tests/test_api_client.py
+++ b/tests/test_api_client.py
@@ -232,6 +232,20 @@ class TestClickUpAPIClient(unittest.TestCase):
         self.assertEqual(mock_get.call_args[1]['timeout'], 30)
 
     @patch('api_client.requests.get')
+    def test_custom_timeout_is_used(self, mock_get):
+        """Test that a custom timeout value is forwarded to requests."""
+        mock_response = Mock()
+        mock_response.ok = True
+        mock_response.status_code = 200
+        mock_response.json.return_value = {}
+        mock_get.return_value = mock_response
+
+        client = ClickUpAPIClient('test_key', timeout=60)
+        client.get('/test')
+
+        self.assertEqual(mock_get.call_args[1]['timeout'], 60)
+
+    @patch('api_client.requests.get')
     @patch('builtins.print')
     def test_shard_routing_error_shard_006(self, mock_print, mock_get):
         """Test 404 with SHARD_006 raises ShardRoutingError."""


### PR DESCRIPTION
Fixes #125

## Changes

- `api_client.py`: added `DEFAULT_TIMEOUT = 30` class constant; `__init__` now accepts `timeout: int = DEFAULT_TIMEOUT`; `requests.get()` uses `self.timeout`
- `tests/test_api_client.py`: added `test_custom_timeout_is_used` — instantiates client with `timeout=60` and asserts that value reaches `requests.get`

## Behaviour

No change at the default. Callers that need a longer timeout can now do:

```python
client = ClickUpAPIClient(api_key, timeout=60)
```