### PR TITLE
chore: release v1.05

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 A powerful, cross-platform Python application for extracting, processing, and exporting tasks from the ClickUp API with beautiful console interfaces and AI-powered summaries.
 
 ![Python](https://img.shields.io/badge/python-3.9%2B-blue.svg)
-![Version](https://img.shields.io/badge/version-1.04-green.svg)
+![Version](https://img.shields.io/badge/version-1.05-green.svg)
 ![Rich](https://img.shields.io/badge/rich-14.0%2B-green.svg)
 ![License](https://img.shields.io/badge/license-MIT-blue.svg)
 

--- a/STATUS.md
+++ b/STATUS.md
@@ -6,7 +6,7 @@ Python CLI for extracting, processing, and exporting tasks from the ClickUp API.
 
 ## Current State — 2026-06-23
 
-Main branch is clean. All known issues resolved. Beads (`bd`) is now active as the task/memory layer beneath GitHub Issues.
+v1.05 release branch open (PRs #126, #127 pending merge before EXE build). CI is green. Beads (`bd`) is active as the task/memory layer beneath GitHub Issues.
 
 ### Components
 
@@ -36,16 +36,19 @@ Main branch is clean. All known issues resolved. Beads (`bd`) is now active as t
 | [#109](https://github.com/J-MaFf/clickup_task_extractor/issues/109) | Fix invalid Gemini model identifier | [#117](https://github.com/J-MaFf/clickup_task_extractor/pull/117) |
 | [#110](https://github.com/J-MaFf/clickup_task_extractor/issues/110) | Make kfj_task_extractor configurable | [#120](https://github.com/J-MaFf/clickup_task_extractor/pull/120) |
 | [#119](https://github.com/J-MaFf/clickup_task_extractor/issues/119) | Adopt beads (bd) for AI task tracking | [#121](https://github.com/J-MaFf/clickup_task_extractor/pull/121) |
+| [#122](https://github.com/J-MaFf/clickup_task_extractor/issues/122) | Add GitHub Actions CI (pytest on push) | [#123](https://github.com/J-MaFf/clickup_task_extractor/pull/123) |
+| [#124](https://github.com/J-MaFf/clickup_task_extractor/issues/124) | Fix null type_config AttributeError | [#126](https://github.com/J-MaFf/clickup_task_extractor/pull/126) |
+| [#125](https://github.com/J-MaFf/clickup_task_extractor/issues/125) | Make API timeout configurable | [#127](https://github.com/J-MaFf/clickup_task_extractor/pull/127) |
 
 ### Open Issues
 
-None.
+PRs #126 and #127 open, awaiting merge.
 
 ## Natural Next Steps
 
-- Add more beads issues as new work is identified (`bd ready` to see queue)
-- Build EXE release for v1.05 once changelog entries are finalized
-- Consider adding GitHub Actions CI for pytest on push
+- Merge PR #126 (bug fix) and PR #127 (timeout) into main
+- Merge this release PR (#128) — bumps version to 1.05, closes changelog
+- Build EXE: `.venv\Scripts\pyinstaller.exe ClickUpTaskExtractor.spec --distpath .\dist\v1.05` (requires Windows + PyInstaller)
 
 ## Prerequisites to Run
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,10 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.05] - 2026-06-23
+
 ### Added
 
-- Adopted **beads** (`bd` v1.0.4, Dolt-backed) as the dependency-graph task/memory layer beneath GitHub Issues. `bd init` wires `.beads/` into the repo; `bd dolt push` syncs issue state to `refs/dolt/data` on origin. CLAUDE.md and AGENTS.md reconciled with `git-policies` (feature-branch + `bd dolt push` at session close; merges to main stay human-gated via PR; `bd remember` scoped to repo-level knowledge). (#119)
-- Added `STATUS.md` — project state snapshot with component table, resolved/open issues, and natural next steps. (#119)
+- Adopted **beads** (`bd` v1.0.4, Dolt-backed) as the dependency-graph task/memory layer beneath GitHub Issues. `bd init` wires `.beads/` into the repo; `bd dolt push` syncs issue state to `refs/dolt/data` on origin. CLAUDE.md and AGENTS.md reconciled with `git-policies` (feature-branch + `bd dolt push` at session close; merges to main stay human-gated via PR; `bd remember` scoped to repo-level knowledge). ([#119](https://github.com/J-MaFf/clickup_task_extractor/pull/119))
+- Added `STATUS.md` — project state snapshot with component table, resolved/open issues, and natural next steps. ([#119](https://github.com/J-MaFf/clickup_task_extractor/pull/119))
 
 - **KFJ Task Extractor** (`kfj_task_extractor.py`): standalone weekly sync that pulls all open tasks from the ClickUp "KFI Jefferson" list into the tracking Google Sheet.
   - Creates a dated tab `KFI Jefferson current tasks (M/D/YY)` at index 0 and renames the workbook title to match; same-day re-runs replace the tab's contents idempotently.
@@ -19,7 +21,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Reuses existing components (`ClickUpAPIClient`, `load_secret_with_fallback`, `TaskRecord`, `sort_tasks_by_priority_and_eta`, `LocationMapper`) without modifying the main extraction workflow.
   - Supports `--dry-run`, `--list-id`, `--sheet-id`, and `--date M/D/YY` overrides.
 - Added `gspread>=6.1.0` dependency for the Google Sheets integration.
-- Added `requirements.lock` — a fully-resolved lock file (`pip freeze` output) for reproducible installs of the exact transitive versions the project is tested against (#108).
+- Added `requirements.lock` — a fully-resolved lock file (`pip freeze` output) for reproducible installs of the exact transitive versions the project is tested against. ([#108](https://github.com/J-MaFf/clickup_task_extractor/pull/108))
+- Added GitHub Actions CI workflow (`.github/workflows/tests.yml`) that runs `pytest tests/ -v` on every push and pull request to `main`. ([#123](https://github.com/J-MaFf/clickup_task_extractor/pull/123))
+- `ClickUpAPIClient` now accepts an optional `timeout` parameter (default: 30 s) so callers can tune the request deadline without modifying source. ([#127](https://github.com/J-MaFf/clickup_task_extractor/pull/127))
 
 ### Changed
 
@@ -39,9 +43,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Corrected the Gemini model identifier from the invalid `gemini-flash-lite-latest` to the published `gemini-2.5-flash-lite` in `ai_summary.py` and `eta_calculator.py`; the value is now overridable via the `GEMINI_MODEL` environment variable. Added smoke tests that reject malformed model ids and the known-bad value (#109).
 - Guarded module-level side effects in `main.py` and `kfj_task_extractor.py` behind `if __name__ == "__main__"`. The virtualenv re-exec, UTF-8 stdio reconfiguration, and `setup_logging()` no longer run at import time, so the modules can be imported by tests and tooling without triggering a process re-exec, mutating `sys.stdout`/`sys.stderr`, or reconfiguring the shared logger (#107).
 
+### Fixed (continued)
+
+- Guarded `type_config` and `options` access in `extractor.py` against explicit `null` from the ClickUp API. Previously `branch_field.get("type_config", {})` returned `None` when the key was present but null, causing `AttributeError` on the subsequent `.get("options")` call. ([#126](https://github.com/J-MaFf/clickup_task_extractor/pull/126))
+- Fixed three pre-existing test failures surfaced by the new CI workflow: `test_interactive_ai_summary` stub endpoint was missing `&subtasks=true`; `test_logger_config` handler isolation broken by module-level `setup_logging()` call in another test file; `test_main` was patching the module-level `None` rather than `_load_runtime_dependencies`. ([#123](https://github.com/J-MaFf/clickup_task_extractor/pull/123))
+
 ### Security
 
-- Disabled `show_locals` in the Rich traceback handler (`logger_config.py`) so unhandled exceptions no longer render local variable contents — a stack frame could hold an API key or other secret, which `show_locals=True` would have printed to the console/logs (#105).
+- Disabled `show_locals` in the Rich traceback handler (`logger_config.py`) so unhandled exceptions no longer render local variable contents — a stack frame could hold an API key or other secret, which `show_locals=True` would have printed to the console/logs. ([#105](https://github.com/J-MaFf/clickup_task_extractor/pull/105))
 
 ## [1.04] - 2026-04-07
 

--- a/version.py
+++ b/version.py
@@ -1,6 +1,6 @@
 """Version information for ClickUp Task Extractor."""
 
-__version__ = "1.04"
+__version__ = "1.05"
 __author__ = "J-MaFf"
 __description__ = (
     "ClickUp Task Extractor - Extract, process, and export tasks from ClickUp API"
@@ -8,7 +8,7 @@ __description__ = (
 __url__ = "https://github.com/J-MaFf/clickup_task_extractor"
 
 # Release information
-RELEASE_DATE = "2026-01-29"
+RELEASE_DATE = "2026-06-23"
 PYTHON_REQUIRES = ">=3.9"
 
 # Feature flags for this version


### PR DESCRIPTION
## Release v1.05

Bumps the project to v1.05 and closes out the `[Unreleased]` changelog section.

> **Merge order:** merge PR #126 and PR #127 first, then this one.

## Changes in this PR

- `version.py` → `1.05`, `RELEASE_DATE` → `2026-06-23`
- `README.md` version badge → `1.05`
- `docs/CHANGELOG.md` — moved all `[Unreleased]` entries to `[1.05] - 2026-06-23`; added entries for CI workflow (#123), configurable timeout (#127), null `type_config` guard (#126), and test isolation fixes (#123)
- `STATUS.md` — updated resolved issues table and next steps

## What's in v1.05

See `docs/CHANGELOG.md` for the full list. Highlights:
- GitHub Actions CI runs pytest on every push/PR to `main`
- `ClickUpAPIClient` timeout is now configurable
- `type_config: null` from ClickUp API no longer causes `AttributeError`
- Three pre-existing test failures fixed (surfaced by CI)
- KFJ Task Extractor, beads adoption, 1Password Environment auth, dep pinning (from prior sessions)

## EXE build

Not included here — run locally after merging:
```powershell
.venv\Scripts\pyinstaller.exe ClickUpTaskExtractor.spec --distpath .\dist\v1.05
```