### PR TITLE
🐛 Gate op run re-exec on actual 1Password Environments-flag support

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed startup crash (`unknown flag: --environment`) when `OP_ENVIRONMENT_ID` is set but a **stable** 1Password CLI is installed. The `op run` Environments flag is beta-only; `main.py` now probes `op run --help` and only re-execs under `op run` when the installed CLI actually advertises the flag (using the correct plural `--environments`). On a stable CLI the re-exec is skipped so authentication falls through to the 1Password SDK path instead of aborting. ([#138](https://github.com/J-MaFf/clickup_task_extractor/issues/138))
+
 ## [1.05] - 2026-06-23
 
 ### Added

--- a/main.py
+++ b/main.py
@@ -130,14 +130,45 @@ def _reexec_in_venv() -> None:
         sys.exit(subprocess.call([venv_python] + sys.argv))
 
 
+def _op_run_environments_flag():
+    """Return the flag `op run` accepts for 1Password Environments, else None.
+
+    The Environments feature ships only in beta builds of the 1Password CLI;
+    stable releases (e.g. 2.34.x) reject the flag with "unknown flag" and exit
+    non-zero, which would abort the re-exec before the normal auth chain runs.
+    Probe the fast, auth-free ``op run --help`` output so we re-exec only when
+    the installed CLI actually supports it. Prefer the documented plural
+    ``--environments``; accept the singular spelling for compatibility.
+    """
+    try:
+        proc = subprocess.run(
+            ["op", "run", "--help"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    help_text = (proc.stdout or "") + (proc.stderr or "")
+    for flag in ("--environments", "--environment"):
+        if flag in help_text:
+            return flag
+    return None
+
+
 def _reexec_under_op_run() -> None:
-    """Re-launch under 'op run --environment' to inject 1Password secrets.
+    """Re-launch under 'op run --environments' to inject 1Password secrets.
 
     When OP_ENVIRONMENT_ID is set, the 1Password CLI beta hangs when called
     from Python subprocess with any handle redirection (STARTF_USESTDHANDLES
     strips console attachment, which op requires for authentication). Using
     subprocess.call (no handle redirection) lets op authenticate and inject
     env vars into the child process, where os.environ picks them up directly.
+
+    The Environments flag is beta-only, so this re-exec is gated on
+    ``_op_run_environments_flag()``: on a stable CLI that lacks the flag we
+    skip the re-exec and fall through to the SDK-based auth chain in auth.py
+    rather than crashing on an unknown flag.
 
     A sentinel env var (_OP_RUN_INJECTED) prevents re-exec loops in case
     CLICKUP_API_KEY is not defined in the 1Password environment.
@@ -150,6 +181,13 @@ def _reexec_under_op_run() -> None:
     import shutil
     if not shutil.which("op"):
         return
+    op_env_flag = _op_run_environments_flag()
+    if not op_env_flag:
+        # Stable `op` builds lack the Environments feature; don't re-exec into a
+        # flag the CLI will reject. Fall through to the normal auth chain, which
+        # resolves OP_ENVIRONMENT_ID via the 1Password SDK (DesktopAuth /
+        # service token) in auth.py instead.
+        return
     # Preserve terminal dimensions so Rich renders correctly in the child
     # process. op run on Windows doesn't propagate console size to its child,
     # causing Rich to fall back to the 80-column default and strip color markup.
@@ -161,7 +199,7 @@ def _reexec_under_op_run() -> None:
             os.environ["LINES"] = str(lines)
     os.environ["_OP_RUN_INJECTED"] = "1"
     sys.exit(subprocess.call(
-        ["op", "run", "--environment", environment_id, "--", sys.executable] + sys.argv
+        ["op", "run", op_env_flag, environment_id, "--", sys.executable] + sys.argv
     ))
 
 
@@ -380,7 +418,7 @@ def main():
         if gemini_api_key:
             return True  # Already have the key
 
-        # Check env var directly — op run --environment injects GEMINI_API_KEY
+        # Check env var directly — op run --environments injects GEMINI_API_KEY
         # into os.environ, and load_secret_with_fallback would hang on Windows
         # trying op environment read from subprocess.
         gemini_api_key = os.environ.get("GEMINI_API_KEY")

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -147,5 +147,94 @@ class MainEntrypointTests(unittest.TestCase):
         self.assertEqual(config_arg.output_format, OutputFormat.CSV)
 
 
+class OpRunReexecTests(unittest.TestCase):
+    """Cover the op-run re-exec gating (issue #138).
+
+    The 1Password Environments flag is beta-only; on a stable `op` CLI the
+    re-exec must be skipped instead of crashing with "unknown flag".
+    """
+
+    def setUp(self) -> None:
+        project_root = Path(__file__).resolve().parents[1]
+        sys.modules.pop("main", None)
+        mocked_executable = str(project_root / ".venv" / "Scripts" / "python.exe")
+        with patch.object(sys, "executable", mocked_executable):
+            self.main = importlib.import_module("main")
+
+    # --- _op_run_environments_flag --------------------------------------
+
+    def test_flag_probe_prefers_plural(self) -> None:
+        proc = MagicMock(stdout="Flags:\n  --environments\n  --environment", stderr="")
+        with patch.object(self.main.subprocess, "run", return_value=proc):
+            self.assertEqual(self.main._op_run_environments_flag(), "--environments")
+
+    def test_flag_probe_accepts_singular(self) -> None:
+        proc = MagicMock(stdout="usage: op run --environment <id>", stderr="")
+        with patch.object(self.main.subprocess, "run", return_value=proc):
+            self.assertEqual(self.main._op_run_environments_flag(), "--environment")
+
+    def test_flag_probe_returns_none_on_stable_cli(self) -> None:
+        # Stable op 2.34.x: only --env-file / --no-masking, no Environments flag.
+        proc = MagicMock(stdout="Flags:\n  --env-file\n  --no-masking", stderr="")
+        with patch.object(self.main.subprocess, "run", return_value=proc):
+            self.assertIsNone(self.main._op_run_environments_flag())
+
+    def test_flag_probe_returns_none_when_op_missing(self) -> None:
+        with patch.object(
+            self.main.subprocess, "run", side_effect=FileNotFoundError("op")
+        ):
+            self.assertIsNone(self.main._op_run_environments_flag())
+
+    # --- _reexec_under_op_run -------------------------------------------
+
+    def test_reexec_skipped_when_flag_unsupported(self) -> None:
+        """The fix for #138: no crash, no re-exec on a stable CLI."""
+        with (
+            patch.dict(self.main.os.environ, {"OP_ENVIRONMENT_ID": "envid"}, clear=True),
+            patch("shutil.which", return_value="C:/op.exe"),
+            patch.object(self.main, "_op_run_environments_flag", return_value=None),
+            patch.object(self.main.subprocess, "call") as mock_call,
+        ):
+            # Must return normally — not raise SystemExit.
+            self.main._reexec_under_op_run()
+        mock_call.assert_not_called()
+
+    def test_reexec_runs_with_detected_flag(self) -> None:
+        with (
+            patch.dict(self.main.os.environ, {"OP_ENVIRONMENT_ID": "envid"}, clear=True),
+            patch.object(self.main.sys, "argv", ["main.py", "--workspace", "X"]),
+            patch("shutil.which", return_value="C:/op.exe"),
+            patch.object(
+                self.main, "_op_run_environments_flag", return_value="--environments"
+            ),
+            patch.object(self.main.subprocess, "call", return_value=0) as mock_call,
+        ):
+            with self.assertRaises(SystemExit):
+                self.main._reexec_under_op_run()
+        cmd = mock_call.call_args.args[0]
+        self.assertEqual(cmd[:4], ["op", "run", "--environments", "envid"])
+        self.assertIn("--", cmd)
+
+    def test_reexec_skipped_when_api_key_present(self) -> None:
+        with (
+            patch.dict(
+                self.main.os.environ,
+                {"OP_ENVIRONMENT_ID": "envid", "CLICKUP_API_KEY": "key"},
+                clear=True,
+            ),
+            patch.object(self.main.subprocess, "call") as mock_call,
+        ):
+            self.main._reexec_under_op_run()
+        mock_call.assert_not_called()
+
+    def test_reexec_skipped_when_no_environment_id(self) -> None:
+        with (
+            patch.dict(self.main.os.environ, {}, clear=True),
+            patch.object(self.main.subprocess, "call") as mock_call,
+        ):
+            self.main._reexec_under_op_run()
+        mock_call.assert_not_called()
+
+
 if __name__ == "__main__":  # pragma: no cover - manual execution safeguard
     unittest.main()


### PR DESCRIPTION
Fixes #138

## Problem

Running `python main.py` with `OP_ENVIRONMENT_ID` set and `CLICKUP_API_KEY` unset aborted immediately on a **stable** 1Password CLI:

```
[ERROR] unknown flag: --environment
Usage:  op run -- <command> <command>... [flags]
[process exited with code 1]
```

`_reexec_under_op_run()` re-execed under `op run --environment <id>` unconditionally. The 1Password Environments feature ships **only in beta** builds of `op`; stable `op` (e.g. 2.34.1) rejects the flag and exits 1 — killing the process **before** the SDK-based auth chain in `auth.py` ever runs. The flag spelling was also wrong (singular `--environment` vs the documented plural `--environments`).

## Fix

- Add `_op_run_environments_flag()`: probe the fast, auth-free `op run --help` output and return the supported flag (prefer plural `--environments`, accept singular for compatibility), else `None`.
- Gate `_reexec_under_op_run()` on it: on a stable CLI, **skip** the re-exec and fall through to the 1Password SDK (`DesktopAuth` / service token) path instead of crashing.
- Use the detected flag name in the `op run` invocation; fix a stale `--environment` comment.

## Testing

- New `OpRunReexecTests` cover the probe (plural / singular / none / op-missing) and the re-exec gating (skip when unsupported, run with detected flag, skip when key present, skip with no environment id).
- Verified against the actual installed `op` **2.34.1**: probe returns `None`, `_reexec_under_op_run()` returns cleanly instead of crashing.

```bash
.\.venv\Scripts\python.exe -m pytest tests/ -q
# 281 passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)