### PR TITLE
🐛 Attempt 1Password Environment auth when OP_ENVIRONMENT_ID is set (no secret reference required)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fixed startup crash (`unknown flag: --environment`) when `OP_ENVIRONMENT_ID` is set but a **stable** 1Password CLI is installed. The `op run` Environments flag is beta-only; `main.py` now probes `op run --help` and only re-execs under `op run` when the installed CLI actually advertises the flag (using the correct plural `--environments`). On a stable CLI the re-exec is skipped so authentication falls through to the 1Password SDK path instead of aborting. ([#138](https://github.com/J-MaFf/clickup_task_extractor/issues/138))
+- Fixed 1Password **Environment** auth being skipped when `CLICKUP_API_SECRET_REFERENCE` is empty (the default, Environment-only setup). The lookup was gated on the `op://` secret reference, but `load_secret_with_fallback()` resolves an Environment from `OP_ENVIRONMENT_ID` + the secret name and needs no reference — so the SDK lookup was never attempted and auth fell through to a manual prompt. `main.py` now performs the lookup when a reference is configured **or** `OP_ENVIRONMENT_ID` is set, for both the ClickUp and Gemini key paths. ([#140](https://github.com/J-MaFf/clickup_task_extractor/issues/140))
 
 ## [1.05] - 2026-06-23
 

--- a/main.py
+++ b/main.py
@@ -372,7 +372,12 @@ def main():
             )
         )
         secret_reference = CLICKUP_API_SECRET_REFERENCE
-        if secret_reference:
+        # The Environment path inside load_secret_with_fallback() is keyed on
+        # OP_ENVIRONMENT_ID and needs no op:// reference. Attempt the lookup
+        # whenever a secret reference is configured OR an Environment ID is set;
+        # gating on secret_reference alone skipped Environment auth entirely for
+        # the recommended OP_ENVIRONMENT_ID-only setup.
+        if secret_reference or environment_id:
             api_key = load_secret_with_fallback(secret_reference, "ClickUp API key")
         if not api_key:
             if is_frozen:
@@ -429,7 +434,11 @@ def main():
         # reference comes from GEMINI_API_SECRET_REFERENCE (config module) and is
         # empty by default so no personal vault path is baked into source.
         gemini_secret_reference = GEMINI_API_SECRET_REFERENCE
-        if gemini_secret_reference:
+        # As with the ClickUp key, the Environment lookup is keyed on
+        # OP_ENVIRONMENT_ID and needs no op:// reference. Attempt it when either
+        # is configured (compute the ID locally — this nested function can run
+        # even when the enclosing api_key branch was skipped).
+        if gemini_secret_reference or os.environ.get("OP_ENVIRONMENT_ID"):
             gemini_api_key = load_secret_with_fallback(
                 gemini_secret_reference, "Gemini API key"
             )

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -146,6 +146,92 @@ class MainEntrypointTests(unittest.TestCase):
         config_arg = mock_extractor_cls.call_args.args[0]
         self.assertEqual(config_arg.output_format, OutputFormat.CSV)
 
+    def test_environment_auth_attempted_without_secret_reference(self) -> None:
+        """Regression: an OP_ENVIRONMENT_ID-only setup must still attempt 1Password.
+
+        With CLICKUP_API_SECRET_REFERENCE empty (the default), the lookup was
+        previously gated on the secret reference, so load_secret_with_fallback
+        was never called and Environment auth was skipped entirely.
+        """
+        main_module = self._import_main_module()
+
+        mock_console = MagicMock()
+        mock_console.input.return_value = ""
+        mock_api_client_cls = MagicMock()
+        mock_extractor_cls = MagicMock()
+
+        with (
+            patch.dict(
+                main_module.os.environ, {"OP_ENVIRONMENT_ID": "envid"}, clear=True
+            ),
+            patch.object(main_module, "CLICKUP_API_SECRET_REFERENCE", ""),
+            patch.object(main_module, "console", mock_console),
+            patch.object(main_module, "get_yes_no_input", return_value=False),
+            patch.object(main_module, "get_choice_input", return_value="Markdown"),
+            patch.object(
+                main_module, "load_secret_with_fallback", return_value="env-key"
+            ) as mock_load_secret,
+            patch.object(
+                main_module,
+                "_load_runtime_dependencies",
+                return_value=(mock_api_client_cls, mock_extractor_cls),
+            ),
+        ):
+            extractor_instance = mock_extractor_cls.return_value
+            extractor_instance.run = MagicMock()
+
+            argv = [
+                str(Path(__file__).resolve().parents[1] / "main.py"),
+                "--workspace",
+                "WS",
+            ]
+            self._run_main_with_args(main_module, argv)
+
+        # The Environment lookup is keyed on OP_ENVIRONMENT_ID and needs no
+        # op:// reference, so it must be attempted with an empty reference.
+        mock_load_secret.assert_called_once_with("", "ClickUp API key")
+        # Key resolved from the Environment — no manual prompt, key flows through.
+        mock_console.input.assert_not_called()
+        mock_api_client_cls.assert_called_once_with("env-key")
+
+    def test_no_op_lookup_when_no_reference_and_no_environment(self) -> None:
+        """Without a reference or OP_ENVIRONMENT_ID, skip 1Password and prompt."""
+        main_module = self._import_main_module()
+
+        mock_console = MagicMock()
+        mock_console.input.return_value = "typed-key"
+        mock_api_client_cls = MagicMock()
+        mock_extractor_cls = MagicMock()
+
+        with (
+            patch.dict(main_module.os.environ, {}, clear=True),
+            patch.object(main_module, "CLICKUP_API_SECRET_REFERENCE", ""),
+            patch.object(main_module, "console", mock_console),
+            patch.object(main_module, "get_yes_no_input", return_value=False),
+            patch.object(main_module, "get_choice_input", return_value="Markdown"),
+            patch.object(
+                main_module, "load_secret_with_fallback", return_value=None
+            ) as mock_load_secret,
+            patch.object(
+                main_module,
+                "_load_runtime_dependencies",
+                return_value=(mock_api_client_cls, mock_extractor_cls),
+            ),
+        ):
+            extractor_instance = mock_extractor_cls.return_value
+            extractor_instance.run = MagicMock()
+
+            argv = [
+                str(Path(__file__).resolve().parents[1] / "main.py"),
+                "--workspace",
+                "WS",
+            ]
+            self._run_main_with_args(main_module, argv)
+
+        mock_load_secret.assert_not_called()
+        mock_console.input.assert_called_once()
+        mock_api_client_cls.assert_called_once_with("typed-key")
+
 
 class OpRunReexecTests(unittest.TestCase):
     """Cover the op-run re-exec gating (issue #138).


### PR DESCRIPTION
Fixes #140

## Problem

After #138 stopped the `op run` crash, `python main.py` with `OP_ENVIRONMENT_ID` set (and no `CLICKUP_API_KEY`) **still** reported `Authentication Failed` and dropped to a manual key prompt — even though the key is in the 1Password Environment.

## Root cause

`main.py` gated the lookup on the `op://` secret reference:

```python
secret_reference = CLICKUP_API_SECRET_REFERENCE
if secret_reference:                      # empty by default → False
    api_key = load_secret_with_fallback(secret_reference, "ClickUp API key")
```

But `load_secret_with_fallback()` resolves an Environment from `OP_ENVIRONMENT_ID` + the secret *name* (`auth.py:224-237`) and never uses `secret_reference` for that path. `CLICKUP_API_SECRET_REFERENCE` is empty by default (the recommended Environment-only setup), so the gate was `False`, the lookup was never made, and auth fell through to the prompt. The Gemini key path had the same bug.

## Fix

- Attempt the lookup when `secret_reference` **or** `OP_ENVIRONMENT_ID` is set — for both the ClickUp and Gemini keys.
- Fix a stale `--environment` comment in the Gemini path.

## Testing

- New regression tests: Environment lookup is attempted with an empty reference when `OP_ENVIRONMENT_ID` is set; skipped (manual prompt) when neither a reference nor `OP_ENVIRONMENT_ID` is present.
- Verified live against the actual 1Password Environment: `load_secret_with_fallback("", "ClickUp API key")` now resolves the key via SDK DesktopAuth (both ClickUp and Gemini keys).

```bash
.\.venv\Scripts\python.exe -m pytest tests/ -q
# 283 passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)