### PR TITLE
✨ Add Claude (Max OAuth) as default AI summary source

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -24,9 +24,17 @@ CLICKUP_TEAM_ID=
 # Provide the ClickUp API key directly (highest precedence after --api-key).
 CLICKUP_API_KEY=
 
-# Provide the Gemini API key directly (used for --ai-summary). Equivalent to
-# the --gemini-api-key CLI flag.
+# Provide the Gemini API key directly (used for --ai-summary --ai-source Gemini).
+# Equivalent to the --gemini-api-key CLI flag.
 # GEMINI_API_KEY is read via --gemini-api-key; set it on the CLI or via 1Password.
+
+# --- AI summary source (optional) -------------------------------------------
+# The default AI summary source is "Claude", which shells out to the local
+# `claude` CLI (Claude Code) using your Max/Pro OAuth — no API key, no Gemini
+# quota. Requires Claude Code installed and signed in. Override the model or
+# per-call timeout if desired:
+# CLAUDE_SUMMARY_MODEL=claude-haiku-4-5-20251001
+# CLAUDE_SUMMARY_TIMEOUT=120
 
 # --- 1Password secret references (optional) ---------------------------------
 # op:// URIs pointing at the items that hold your API keys. When set, the tool

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,7 +23,7 @@ clickup_task_extractor/
 ├── auth.py                # Multi-fallback API key loader (CLI → env → 1Password SDK → CLI → prompt)
 ├── api_client.py          # APIClient protocol + ClickUpAPIClient (requests, 30s timeout)
 ├── extractor.py           # ClickUpTaskExtractor workflow, export context mgr, interactive UI
-├── ai_summary.py          # Gemini summaries, tiered model strategy, daily quota detection
+├── ai_summary.py          # AI summaries: Claude CLI (default, Max OAuth) + Gemini tiered strategy
 ├── mappers.py             # Prompts, date filters, custom field mapping, image extraction
 ├── logger_config.py       # Rich-enhanced logging setup
 ├── version.py             # Version metadata
@@ -125,8 +125,11 @@ All retrieval is logged (DEBUG level); failures don't raise exceptions—they re
 - `export_file()` context manager (creates parent dirs, handles I/O errors)
 - Markdown/HTML rendering (uses `get_export_fields()` for column order)
 
-**`ai_summary.py`**: Google Gemini integration
-- **Tiered model strategy** (on rate limit, automatically switches tiers):
+**`ai_summary.py`**: AI summary generation (two providers)
+
+- **Claude CLI path (`get_claude_summary`)** — the **default** generative source (`AISource.CLAUDE`). Shells out to the local `claude` CLI in headless print mode (`claude -p` over stdin) using the user's Claude Code OAuth / Max subscription — no API key, not subject to Gemini quotas. Model via `CLAUDE_SUMMARY_MODEL` (default `claude-haiku-4-5-20251001`), timeout via `CLAUDE_SUMMARY_TIMEOUT`. A usage-limit hit sets the global `_claude_available=False` to skip the rest of the run; missing CLI / errors / timeouts return None → caller falls back to base notes. `claude_cli_available()` checks PATH.
+- **Google Gemini path (`get_ai_summary`)** — selectable via `AISource.GEMINI`; `AISource.BOTH` resolves the ClickUp `Summary` field first, then falls back to **Claude** (not Gemini).
+- Gemini **Tiered model strategy** (on rate limit, automatically switches tiers):
   - Tier 1: `gemini-2.5-flash-lite` (500 RPD free tier)
   - Tier 2: `gemini-2.5-pro` (1,500 RPD separate bucket)
   - Tier 3: `gemini-2.0-flash` (500 RPD fallback)

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A powerful, cross-platform Python application for extracting, processing, and ex
 
 - 🔐 **Secure Authentication**: Multiple authentication methods including 1Password integration
 - 🎨 **Beautiful UI**: Rich console interfaces with progress bars, panels, and styled output
-- 🤖 **AI Summaries**: Optional Google Gemini AI integration for intelligent task summaries
+- 🤖 **AI Summaries**: Optional intelligent task summaries via Claude (your Max/Pro OAuth, no API key — the default), Google Gemini, or the ClickUp Summary field
 - 📅 **Automated ETA Calculation**: Intelligent ETA population for tasks without due dates
   - Uses existing due dates when available
   - AI-powered ETA estimation based on task context
@@ -30,7 +30,7 @@ A powerful, cross-platform Python application for extracting, processing, and ex
 - Python 3.11 or higher
 - ClickUp API token
 - Optional: 1Password Environment support for Python, or 1Password CLI for legacy secret references
-- Optional: Google Gemini API key for AI summaries
+- Optional: AI summaries — Claude Code (default source; uses your Max/Pro OAuth, no key) or a Google Gemini API key
 
 ### Installation
 
@@ -156,7 +156,7 @@ python main.py --workspace "MyWorkspace" --space "MySpace"
 When certain options are not specified via CLI arguments, the application will prompt you interactively:
 
 1. **Interactive Mode**: Asks if you want to review and select which tasks to export
-2. **AI Summary**: Asks if you want to enable AI-powered task summaries (requires Gemini API key)
+2. **AI Summary**: Asks if you want to enable AI-powered task summaries and which source to use (Claude by default — no API key; Gemini requires a key)
 3. **Output Format**: Asks you to choose your preferred export format (Markdown or HTML)
 
 Each prompt provides clear options and defaults, making it easy to configure the application on-the-fly without remembering all CLI flags.
@@ -241,7 +241,7 @@ is set) and parsed in-memory — credentials are never written to disk.
 ## 🔧 Development workflow
 
 - Install deps via `pip install -r requirements.txt` (compatible-release `~=` pins) or `pip install -r requirements.lock` for the exact tested versions; optional features require `onepassword-sdk` and `google-genai` which are already listed. Regenerate `requirements.lock` with `pip freeze` from a clean venv after changing `requirements.txt`.
-- Run the extractor with `python main.py` (Markdown export by default). Set the workspace and space via `--workspace`/`--space` or the `CLICKUP_WORKSPACE_NAME`/`CLICKUP_SPACE_NAME` environment variables (see [Configuration](#-configuration)). Other flags: `--output-format`, `--interactive`, `--include-completed`, `--date-filter`, `--ai-summary`, and `--gemini-api-key`.
+- Run the extractor with `python main.py` (Markdown export by default). Set the workspace and space via `--workspace`/`--space` or the `CLICKUP_WORKSPACE_NAME`/`CLICKUP_SPACE_NAME` environment variables (see [Configuration](#-configuration)). Other flags: `--output-format`, `--interactive`, `--include-completed`, `--date-filter`, `--ai-summary`, `--ai-source`, and `--gemini-api-key`.
 - Authentication falls back in this order: CLI flag → env var `CLICKUP_API_KEY` → 1Password Environment (`OP_ENVIRONMENT_ID`: SDK first, then `op environment read`) → 1Password SDK secret references → `op read` CLI → manual prompt.
 - Logging comes from `logger_config.setup_logging`; pass `use_rich=False` for plain output or a `log_file` path to persist logs.
 - All exports land under `output/`, named with `default_output_path()` which strips leading zeros for cross-platform friendly filenames.
@@ -267,7 +267,8 @@ is set) and parsed in-memory — credentials are never written to disk.
 | `--interactive` | Enable interactive task selection | Prompted |
 | `--date-filter` | Date filter: `AllOpen`, `ThisWeek`, `LastWeek` | `AllOpen` |
 | `--ai-summary` | Enable AI summaries | Prompted |
-| `--gemini-api-key` | Google Gemini API key | From 1Password |
+| `--ai-source` | Summary source: `Claude`, `Gemini`, `ClickUp`, `Both` | `Claude` |
+| `--gemini-api-key` | Google Gemini API key (only for `--ai-source Gemini`) | From 1Password |
 
 ### Authentication Methods (Priority Order)
 
@@ -353,17 +354,28 @@ clickup_task_extractor/
 
 ## 🤖 AI Integration
 
-Optional Google Gemini AI integration provides:
+Optional AI integration provides intelligent 1-2 sentence task summaries from several sources, selectable with `--ai-source`:
 
-- Intelligent 1-2 sentence task summaries
-- Automatic rate limiting and retry logic with tiered model fallback
-- Daily quota exhaustion detection to prevent wasted API calls
-- Graceful fallback to original content if AI fails
+| Source | What it uses | API key? |
+| --- | --- | --- |
+| `Claude` (**default**) | The local `claude` CLI (Claude Code) in headless print mode, via your **Max/Pro OAuth** | No — uses your subscription |
+| `Gemini` | Google Gemini API with tiered model fallback | Yes (Gemini API key) |
+| `ClickUp` | The task's existing ClickUp `Summary` custom field | No |
+| `Both` | ClickUp `Summary` field first, then falls back to **Claude** | No |
+
+The **Claude** source needs no API key and is **not subject to Gemini's free-tier rate limits**, so it's the recommended default. It requires [Claude Code](https://docs.claude.com/en/docs/claude-code) installed and signed in. Override the model with `CLAUDE_SUMMARY_MODEL` (default `claude-haiku-4-5-20251001`) and the per-call timeout with `CLAUDE_SUMMARY_TIMEOUT` (seconds).
+
+All sources gracefully fall back to the raw task content if the provider is unavailable, errors, or hits a usage limit.
 
 Enable AI summaries:
 
 ```bash
-python main.py --ai-summary --gemini-api-key YOUR_KEY
+# Default: Claude via your Max subscription (no key)
+python main.py --ai-summary
+
+# Or explicitly pick a source
+python main.py --ai-summary --ai-source Claude
+python main.py --ai-summary --ai-source Gemini --gemini-api-key YOUR_KEY
 ```
 
 ### Model Tiering & Rate Limiting

--- a/STATUS.md
+++ b/STATUS.md
@@ -2,11 +2,13 @@
 
 ## What This Is
 
-Python CLI for extracting, processing, and exporting tasks from the ClickUp API. Supports Markdown, HTML, and CSV output, optional AI summaries via Google Gemini, 1Password-backed authentication, and a Rich console UI with interactive task selection and priority/ETA sorting.
+Python CLI for extracting, processing, and exporting tasks from the ClickUp API. Supports Markdown, HTML, and CSV output, optional AI summaries (Claude via Max/Pro OAuth by default, or Google Gemini, or the ClickUp Summary field), 1Password-backed authentication, and a Rich console UI with interactive task selection and priority/ETA sorting.
 
-## Current State — 2026-06-23
+## Current State — 2026-06-26
 
-**v1.05 shipped** — EXE built and published to GitHub Releases. Main is clean. No open issues. Beads (`bd`) is active as the task/memory layer beneath GitHub Issues.
+**v1.05 shipped.** Beads (`bd`) is active as the task/memory layer beneath GitHub Issues.
+
+**In progress:** `feat/claude-ai-summary-source` ([#144](https://github.com/J-MaFf/clickup_task_extractor/issues/144)) — adds **Claude** as an AI summary source (local `claude` CLI / Max OAuth, no API key) and makes it the default generative summarizer, replacing rate-limited Gemini. Gemini stays available via `--ai-source Gemini`. All 296 tests pass.
 
 ### Components
 
@@ -17,7 +19,7 @@ Python CLI for extracting, processing, and exporting tasks from the ClickUp API.
 | `auth.py` | Multi-fallback API key loader |
 | `api_client.py` | `APIClient` protocol + `ClickUpAPIClient` |
 | `extractor.py` | Main workflow, export context manager, interactive UI |
-| `ai_summary.py` | Gemini summaries, tiered model strategy, daily quota detection |
+| `ai_summary.py` | AI summaries: Claude CLI path (default, Max OAuth) + Gemini tiered model strategy / quota detection |
 | `mappers.py` | Prompts, date filters, custom field mapping, image extraction |
 | `kfj_task_extractor.py` | Standalone KFJ weekly Google Sheets sync |
 | `logger_config.py` | Rich-enhanced logging setup |
@@ -42,10 +44,11 @@ Python CLI for extracting, processing, and exporting tasks from the ClickUp API.
 
 ### Open Issues
 
-None.
+- [#144](https://github.com/J-MaFf/clickup_task_extractor/issues/144) — Add Claude (Max OAuth) AI summary source, make it default (in review on `feat/claude-ai-summary-source`)
 
 ## Natural Next Steps
 
+- Follow-up: let `eta_calculator.py` use the Claude CLI too (currently Gemini-only; falls back to deterministic priority/status ETA when no Gemini key)
 - File new beads issues as work is identified (`bd create`)
 - Identify any bugs or improvements from v1.05 usage
 

--- a/ai_summary.py
+++ b/ai_summary.py
@@ -481,6 +481,16 @@ Focus on what I have done or still need to do. Be specific and actionable. Outpu
         "text",
     ]
 
+    # Force the CLI to authenticate with the user's Claude Code OAuth / Max
+    # subscription rather than an API key: if ANTHROPIC_API_KEY / AUTH_TOKEN are
+    # present in the environment, the CLI could otherwise bill the API. Scrubbing
+    # them is a no-op when they are absent (the normal subscription setup).
+    child_env = {
+        k: v
+        for k, v in os.environ.items()
+        if k not in ("ANTHROPIC_API_KEY", "ANTHROPIC_AUTH_TOKEN")
+    }
+
     try:
         proc = subprocess.run(
             cmd,
@@ -491,6 +501,7 @@ Focus on what I have done or still need to do. Be specific and actionable. Outpu
             errors="replace",
             timeout=_CLAUDE_TIMEOUT_SECONDS,
             cwd=tempfile.gettempdir(),
+            env=child_env,
         )
     except subprocess.TimeoutExpired:
         _emit(

--- a/ai_summary.py
+++ b/ai_summary.py
@@ -10,6 +10,9 @@ Contains:
 """
 
 import os
+import shutil
+import subprocess
+import tempfile
 import time
 from typing import Callable, Mapping, Sequence, TypeAlias
 
@@ -24,6 +27,31 @@ from typing import Callable, Mapping, Sequence, TypeAlias
 # Overridable via the GEMINI_MODEL environment variable so the model can be
 # bumped without a code change.
 GEMINI_MODEL = os.environ.get("GEMINI_MODEL", "gemini-2.5-flash-lite")
+
+# Claude model used for AI summaries via the local `claude` CLI (headless print
+# mode). This path uses the user's Claude Code OAuth / Max subscription rather
+# than an API key, so it sidesteps Gemini's free-tier rate limits.
+#
+# Defaults to Haiku for speed and light subscription usage on short summaries;
+# overridable via CLAUDE_SUMMARY_MODEL (accepts a full id or a CLI alias like
+# "haiku"/"sonnet"/"opus").
+CLAUDE_SUMMARY_MODEL = os.environ.get(
+    "CLAUDE_SUMMARY_MODEL", "claude-haiku-4-5-20251001"
+)
+
+# System prompt that constrains the CLI to a plain-text, first-person summary
+# with no tool use or markdown. Replacing the default system prompt (and
+# excluding dynamic sections) also stops the CLI from loading the surrounding
+# project's CLAUDE.md/git context, keeping calls fast and clean.
+_CLAUDE_SUMMARY_SYSTEM_PROMPT = (
+    "You are a task-status summarizer. Given a task's fields, reply with ONLY a "
+    "concise 1-2 sentence summary of the task's current status, written in the "
+    "first person (e.g. 'I completed...', 'I need to...'). Output plain text "
+    "with no markdown, no preamble, and no tool use."
+)
+
+# Seconds to allow a single `claude` CLI summary call before giving up.
+_CLAUDE_TIMEOUT_SECONDS = int(os.environ.get("CLAUDE_SUMMARY_TIMEOUT", "120"))
 
 # Rich console imports - create singleton instance with proper encoding for Windows
 try:
@@ -50,6 +78,12 @@ SummaryResult: TypeAlias = str | None
 # Global state for tracking API availability
 _api_available = True
 _last_error_message = ""
+
+# Global state for the Claude CLI path. Once a usage/rate limit is hit we stop
+# calling the CLI for the rest of the run (mirrors Gemini's _api_available),
+# since the Max subscription limit won't clear within a single extraction.
+_claude_available = True
+_claude_missing_warned = False
 
 # Google GenAI SDK imports (google.genai)
 try:
@@ -128,6 +162,13 @@ def _reset_api_state() -> None:
     global _api_available, _last_error_message
     _api_available = True
     _last_error_message = ""
+
+
+def _reset_claude_state() -> None:
+    """Reset Claude CLI availability state (for testing or manual reset)."""
+    global _claude_available, _claude_missing_warned
+    _claude_available = True
+    _claude_missing_warned = False
 
 
 def _normalize_field_entries(
@@ -350,3 +391,137 @@ def get_ai_summary(
 
     # Fallback (should not reach here, but safety net)
     return field_block
+
+
+def claude_cli_available() -> bool:
+    """Return True when the `claude` CLI is resolvable on PATH."""
+    return shutil.which("claude") is not None
+
+
+def _emit(message: str) -> None:
+    """Print a message via Rich when available, else plain print."""
+    if RICH_AVAILABLE and _console:
+        _console.print(message)
+    else:
+        # Strip Rich markup for the plain fallback.
+        import re
+
+        print(re.sub(r"\[/?[^\]]*\]", "", message))
+
+
+def get_claude_summary(
+    task_name: str,
+    field_entries: Sequence[tuple[str, str]] | Mapping[str, str],
+    progress_pause_callback: Callable[[], None] | None = None,
+) -> SummaryResult:
+    """
+    Generate a concise 1-2 sentence task summary via the local ``claude`` CLI.
+
+    Runs ``claude -p`` in headless print mode, which uses the user's Claude Code
+    OAuth / Max subscription (no API key) and therefore avoids Gemini's
+    free-tier rate limits. The prompt is supplied over stdin to avoid Windows
+    command-line length/quoting limits, and the CLI runs from a temp directory
+    with a replacement system prompt so it does not load the surrounding
+    project's context or attempt tool use.
+
+    Args:
+        task_name: Name of the task.
+        field_entries: Iterable of (field label, value) pairs to summarize.
+        progress_pause_callback: Optional callback to pause/resume progress bars
+            (unused for now; accepted for parity with get_ai_summary()).
+
+    Returns:
+        The summary string, or None if the CLI is unavailable, errors, hits a
+        usage limit, or returns no text (callers fall back to base content).
+    """
+    global _claude_available, _claude_missing_warned, _last_error_message
+
+    if not _claude_available:
+        _emit(
+            f"[dim][⊘] Claude usage limited - skipping AI summary for: {task_name}[/dim]"
+        )
+        return None
+
+    normalized_entries = _normalize_field_entries(field_entries)
+    field_block = "\n".join(
+        f"{label}: {value}" for label, value in normalized_entries if label
+    )
+    if not field_block:
+        return "No content available for summary."
+
+    claude_bin = shutil.which("claude")
+    if not claude_bin:
+        if not _claude_missing_warned:
+            _claude_missing_warned = True
+            _emit(
+                "[yellow]Warning: 'claude' CLI not found on PATH - install Claude Code "
+                "or choose a different --ai-source. Using fallback content.[/yellow]"
+            )
+        return None
+
+    prompt = f"""Summarize the current status of this task in 1-2 first-person sentences.
+
+Task: {task_name}
+
+Here are the available fields (ignore any marked "(not provided)"):
+
+{field_block}
+
+Focus on what I have done or still need to do. Be specific and actionable. Output only the summary sentence(s)."""
+
+    cmd = [
+        claude_bin,
+        "-p",
+        "--model",
+        CLAUDE_SUMMARY_MODEL,
+        "--system-prompt",
+        _CLAUDE_SUMMARY_SYSTEM_PROMPT,
+        "--exclude-dynamic-system-prompt-sections",
+        "--output-format",
+        "text",
+    ]
+
+    try:
+        proc = subprocess.run(
+            cmd,
+            input=prompt,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            timeout=_CLAUDE_TIMEOUT_SECONDS,
+            cwd=tempfile.gettempdir(),
+        )
+    except subprocess.TimeoutExpired:
+        _emit(
+            f"⚠️ [yellow]Claude summary timed out for: {task_name}. Using fallback content.[/yellow]"
+        )
+        return None
+    except OSError as exc:
+        _emit(f"❌ [red]Error launching 'claude' CLI: {str(exc)[:100]}[/red]")
+        return None
+
+    if proc.returncode != 0:
+        error_str = (proc.stderr or proc.stdout or "").strip()
+        _last_error_message = error_str[:150]
+        if _is_rate_limit_error(error_str) or "usage limit" in error_str.lower():
+            _claude_available = False
+            _emit(
+                "[red]Claude usage limit reached - AI summaries will be skipped for "
+                "this extraction.[/red]"
+            )
+        else:
+            _emit(f"❌ [red]Claude CLI error: {error_str[:100]}[/red]")
+        return None
+
+    summary = (proc.stdout or "").strip()
+    if not summary:
+        _emit(
+            f"⚠️ [yellow]Empty Claude response for: {task_name}. Using fallback content.[/yellow]"
+        )
+        return None
+
+    summary = summary.replace("\n", " ").strip()
+    if not summary.endswith("."):
+        summary += "."
+    return summary

--- a/config.py
+++ b/config.py
@@ -40,6 +40,7 @@ class AISource(Enum):
     BOTH = "Both"
     CLICKUP = "ClickUp"
     GEMINI = "Gemini"
+    CLAUDE = "Claude"
 
 
 # Priority sorting order (higher value = higher priority)
@@ -333,7 +334,10 @@ class ClickUpConfig:
     date_filter: DateFilter = DateFilter.ALL_OPEN
     enable_ai_summary: bool = False
     gemini_api_key: str | None = None
-    ai_source: AISource = AISource.BOTH
+    # Claude (via the local `claude` CLI / Max OAuth) is the default generative
+    # summarizer; it needs no API key and avoids Gemini's free-tier rate limits.
+    # Gemini stays selectable via AISource.GEMINI.
+    ai_source: AISource = AISource.CLAUDE
     ai_clickup_field_id: str | None = CLICKUP_AI_SUMMARY_FIELD_ID
     output_format: OutputFormat = OutputFormat.MARKDOWN
     interactive_selection: bool = False

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added **Claude** as an AI summary source that shells out to the local `claude` CLI in headless print mode (`claude -p … --output-format text`), using your Claude Code **OAuth / Max subscription** — no API key required, and not subject to Gemini's free-tier rate limits. Select with `--ai-source Claude` (now the interactive default). The model is overridable via `CLAUDE_SUMMARY_MODEL` (default `claude-haiku-4-5-20251001`) and the per-call timeout via `CLAUDE_SUMMARY_TIMEOUT`. If a usage limit is hit, the CLI is missing, or a call errors, summaries fall back to raw field content (mirroring the Gemini failure path). ([#144](https://github.com/J-MaFf/clickup_task_extractor/issues/144))
+
+### Changed
+
+- **Claude is now the default AI summary source**, replacing Gemini as the default generative summarizer (Gemini hit free-tier rate limits frequently). `--ai-source Both` now resolves the ClickUp `Summary` field first, then falls back to **Claude**. Gemini remains fully available via `--ai-source Gemini`, and a Gemini API key is only loaded/prompted when that source is selected. ([#144](https://github.com/J-MaFf/clickup_task_extractor/issues/144))
+
 ### Fixed
 
 - Fixed startup crash (`unknown flag: --environment`) when `OP_ENVIRONMENT_ID` is set but a **stable** 1Password CLI is installed. The `op run` Environments flag is beta-only; `main.py` now probes `op run --help` and only re-execs under `op run` when the installed CLI actually advertises the flag (using the correct plural `--environments`). On a stable CLI the re-exec is skipped so authentication falls through to the 1Password SDK path instead of aborting. ([#138](https://github.com/J-MaFf/clickup_task_extractor/issues/138))

--- a/extractor.py
+++ b/extractor.py
@@ -53,7 +53,7 @@ from api_client import (
     AuthenticationError,
     ShardRoutingError,
 )
-from ai_summary import get_ai_summary
+from ai_summary import get_ai_summary, get_claude_summary
 from mappers import get_yes_no_input, get_choice_input, get_date_range, extract_images, LocationMapper
 from eta_calculator import calculate_eta
 
@@ -476,11 +476,13 @@ class ClickUpTaskExtractor:
                             name = task.get("name", "Unknown Task")
                             task_name = name[:30] + ("..." if len(name) > 30 else "")
 
-                            # Update per-list progress description with current task
-                            # Only show AI indicator if AI will actually be generated (not in interactive mode)
+                            # Update per-list progress description with current task.
+                            # Show the AI indicator whenever a summary will be
+                            # generated in this pass (AI enabled, non-interactive).
+                            # The Claude source needs no API key, so don't gate on
+                            # gemini_api_key here.
                             if (
                                 self.config.enable_ai_summary
-                                and self.config.gemini_api_key
                                 and not self.config.interactive_selection
                             ):
                                 progress.update(
@@ -539,9 +541,10 @@ class ClickUpTaskExtractor:
 
             console.print(stats_table)
 
-            # Handle AI summary if enabled
+            # Handle AI summary if enabled. Only load a Gemini key when the
+            # selected source is actually Gemini; Claude/Both/ClickUp need none.
             if (
-                self.config.enable_ai_summary
+                self._source_needs_gemini_key()
                 and not self.config.gemini_api_key
                 and self.load_gemini_key_func
             ):
@@ -572,7 +575,8 @@ class ClickUpTaskExtractor:
                             Panel(
                                 f"[bold blue]🤖 AI Summary Available[/bold blue]\n"
                                 f"You have selected [bold cyan]{len(all_tasks)}[/bold cyan] task(s) for export.\n"
-                                f"AI summary can generate concise 1-2 sentence summaries using Google Gemini.",
+                                f"AI summary can generate concise 1-2 sentence summaries using "
+                                f"[cyan]{self.config.ai_source.value}[/cyan].",
                                 title="AI Enhancement",
                                 style="blue",
                             )
@@ -581,31 +585,36 @@ class ClickUpTaskExtractor:
                             "Would you like to enable AI summaries for the selected tasks? (y/n): ",
                             default_on_interrupt=False,
                         ):
-                            # Try to load Gemini API key
-                            gemini_key_loaded = False
-                            if self.load_gemini_key_func:
-                                if self.load_gemini_key_func():
-                                    gemini_key_loaded = True
-                                    console.print(
-                                        "✅ [green]Gemini API key loaded from 1Password.[/green]"
-                                    )
+                            if self.config.ai_source == AISource.GEMINI:
+                                # Gemini is the only source that needs an API key.
+                                gemini_key_loaded = False
+                                if self.load_gemini_key_func:
+                                    if self.load_gemini_key_func():
+                                        gemini_key_loaded = True
+                                        console.print(
+                                            "✅ [green]Gemini API key loaded from 1Password.[/green]"
+                                        )
 
-                            if not gemini_key_loaded:
-                                gemini_key = console.input(
-                                    "[bold cyan]🔑 Enter Gemini API Key (or press Enter to skip): [/bold cyan]"
-                                ).strip()
-                                if gemini_key:
-                                    self.config.gemini_api_key = gemini_key
-                                    gemini_key_loaded = True
-                                    console.print(
-                                        "✅ [green]Manual Gemini API key entered.[/green]"
-                                    )
-                                else:
-                                    console.print(
-                                        "ℹ️ [yellow]Proceeding without AI summary.[/yellow]"
-                                    )
+                                if not gemini_key_loaded:
+                                    gemini_key = console.input(
+                                        "[bold cyan]🔑 Enter Gemini API Key (or press Enter to skip): [/bold cyan]"
+                                    ).strip()
+                                    if gemini_key:
+                                        self.config.gemini_api_key = gemini_key
+                                        gemini_key_loaded = True
+                                        console.print(
+                                            "✅ [green]Manual Gemini API key entered.[/green]"
+                                        )
+                                    else:
+                                        console.print(
+                                            "ℹ️ [yellow]Proceeding without AI summary.[/yellow]"
+                                        )
 
-                            if gemini_key_loaded and self.config.gemini_api_key:
+                                if gemini_key_loaded and self.config.gemini_api_key:
+                                    self.config.enable_ai_summary = True
+                                    should_generate_ai = True
+                            else:
+                                # Claude / Both / ClickUp need no API key.
                                 self.config.enable_ai_summary = True
                                 should_generate_ai = True
                         else:
@@ -645,7 +654,7 @@ class ClickUpTaskExtractor:
                                 ai_fields,
                                 base_notes,
                                 clickup_ai_summary,
-                                allow_gemini=True,
+                                allow_generative=True,
                             )
                         console.print(
                             "✅ [bold green]AI summaries generated for all selected tasks.[/bold green]"
@@ -851,7 +860,7 @@ class ClickUpTaskExtractor:
                 ai_field_items,
                 base_notes,
                 clickup_ai_summary,
-                allow_gemini=not self.config.interactive_selection,
+                allow_generative=not self.config.interactive_selection,
             )
 
             # Extract images (like original)
@@ -962,50 +971,96 @@ class ClickUpTaskExtractor:
             )
         )
 
+    def _source_needs_gemini_key(self) -> bool:
+        """True only when the selected AI source actually requires a Gemini key.
+
+        Claude/Both/ClickUp sources never call Gemini (Both falls back to the
+        Claude CLI), so they must not trigger a Gemini key load or prompt.
+        """
+        return (
+            self.config.enable_ai_summary
+            and self.config.ai_source == AISource.GEMINI
+        )
+
+    def _generate_claude_notes(
+        self,
+        task_name: str,
+        ai_field_items: tuple[tuple[str, str], ...] | list[tuple[str, str]],
+        base_notes: str,
+    ) -> str:
+        """Summarize via the Claude CLI, falling back to base notes on failure."""
+        ai_notes = get_claude_summary(
+            task_name,
+            ai_field_items,
+            progress_pause_callback=self._pause_progress_callback,
+        )
+        return ai_notes or base_notes
+
+    def _generate_gemini_notes(
+        self,
+        task_name: str,
+        ai_field_items: tuple[tuple[str, str], ...] | list[tuple[str, str]],
+        base_notes: str,
+        gemini_key: str,
+    ) -> str:
+        """Summarize via Gemini, falling back to base notes on failure."""
+        ai_notes = get_ai_summary(
+            task_name,
+            ai_field_items,
+            gemini_key,
+            progress_pause_callback=self._pause_progress_callback,
+        )
+        return ai_notes or base_notes
+
     def _apply_ai_source(
         self,
         task_name: str,
         ai_field_items: tuple[tuple[str, str], ...] | list[tuple[str, str]],
         base_notes: str,
         clickup_ai_summary: str | None,
-        allow_gemini: bool,
+        allow_generative: bool,
     ) -> str:
-        """Resolve notes based on AI source selection and availability."""
+        """Resolve notes based on AI source selection and availability.
+
+        ``allow_generative`` gates the generative providers (Claude/Gemini) for
+        this pass: in interactive mode the bulk pass sets it False so summaries
+        are only generated for tasks the user actually selects.
+        """
 
         if not self.config.enable_ai_summary:
             return base_notes
 
         source = self.config.ai_source
-        gemini_key = self.config.gemini_api_key if allow_gemini else None
+        gemini_key = self.config.gemini_api_key if allow_generative else None
         clickup_value = (clickup_ai_summary or "").strip()
 
         if source == AISource.CLICKUP:
             return clickup_value or base_notes
 
-        if source == AISource.GEMINI:
-            if gemini_key:
-                ai_notes = get_ai_summary(
-                    task_name,
-                    ai_field_items,
-                    gemini_key,
-                    progress_pause_callback=self._pause_progress_callback,
+        if source == AISource.CLAUDE:
+            if allow_generative:
+                return self._generate_claude_notes(
+                    task_name, ai_field_items, base_notes
                 )
-                return ai_notes or base_notes
             if clickup_value:
                 return clickup_value
             return base_notes
 
-        # AISource.BOTH
+        if source == AISource.GEMINI:
+            if gemini_key:
+                return self._generate_gemini_notes(
+                    task_name, ai_field_items, base_notes, gemini_key
+                )
+            if clickup_value:
+                return clickup_value
+            return base_notes
+
+        # AISource.BOTH: prefer the ClickUp Summary field, then fall back to the
+        # Claude CLI (no API key / no Gemini quota).
         if clickup_value:
             return clickup_value
-        if gemini_key:
-            ai_notes = get_ai_summary(
-                task_name,
-                ai_field_items,
-                gemini_key,
-                progress_pause_callback=self._pause_progress_callback,
-            )
-            return ai_notes or base_notes
+        if allow_generative:
+            return self._generate_claude_notes(task_name, ai_field_items, base_notes)
         return base_notes
 
     def interactive_include(self, tasks: TaskList) -> TaskList:

--- a/main.py
+++ b/main.py
@@ -30,6 +30,7 @@ except ImportError:
     sys.exit(1)
 
 # Import project modules
+from ai_summary import claude_cli_available
 from auth import load_secret_with_fallback
 from config import (
     ClickUpConfig,
@@ -308,13 +309,18 @@ def main():
     parser.add_argument(
         "--ai-summary",
         action="store_true",
-        help="Enable AI summary (requires Gemini API key - will auto-load from 1Password Environment or SDK if available)",
+        help="Enable AI summary (defaults to the Claude source, which needs no API key; Gemini source auto-loads a key from 1Password Environment/SDK if available)",
     )
     parser.add_argument(
         "--ai-source",
         type=str,
-        choices=["Both", "ClickUp", "Gemini"],
-        help="AI summary source: Both (prefer ClickUp AI field, fallback to Gemini), ClickUp only, or Gemini only (default: Both)",
+        choices=["Both", "ClickUp", "Gemini", "Claude"],
+        help=(
+            "AI summary source: Claude (default; uses the local 'claude' CLI via "
+            "your Claude Max OAuth - no API key, no Gemini quota), Gemini (Google "
+            "API key), ClickUp (the task's Summary field only), or Both (ClickUp "
+            "field first, then Claude). Default: Claude"
+        ),
     )
     parser.add_argument(
         "--ai-clickup-field-id",
@@ -449,11 +455,13 @@ def main():
             return False
 
     def ai_source_includes_gemini(source_value: str | None) -> bool:
+        # Only the Gemini source needs a Google API key. The default (Claude) and
+        # Both (ClickUp field -> Claude) sources use the keyless claude CLI.
         try:
-            src = AISource(source_value) if source_value else AISource.BOTH
+            src = AISource(source_value) if source_value else AISource.CLAUDE
         except ValueError:
-            src = AISource.BOTH
-        return src in (AISource.BOTH, AISource.GEMINI)
+            src = AISource.CLAUDE
+        return src == AISource.GEMINI
 
     # If AI summary flag was explicitly used, load the key now when Gemini is required
     if (
@@ -498,17 +506,23 @@ def main():
     if not args.ai_summary:
         console.print("\n[bold blue]🤖 AI Summary[/bold blue]")
         console.print(
-            "AI summary can generate concise 1-2 sentence summaries of task status using Google Gemini."
+            "AI summary can generate concise 1-2 sentence summaries of task status. "
+            "By default this uses Claude via your Max subscription (no API key); "
+            "Gemini and the ClickUp Summary field are also available."
         )
         if get_yes_no_input("Would you like to enable AI summaries for tasks? (y/n): "):
             args.ai_summary = True
             if not args.ai_source:
                 console.print(
-                    "Select which AI to use. Gemini is option 1 (default), ClickUp AI is option 2, and Both is option 3."
+                    "Select which AI to use. Claude is option 1 (default; uses your "
+                    "Claude Max subscription, no API key), Gemini is option 2, "
+                    "ClickUp AI is option 3, and Both (ClickUp field then Claude) is "
+                    "option 4."
                 )
                 ai_source_choice = get_choice_input(
-                    "Choose AI source (1-3) [default: Gemini]: ",
+                    "Choose AI source (1-4) [default: Claude]: ",
                     [
+                        AISource.CLAUDE.value,
                         AISource.GEMINI.value,
                         AISource.CLICKUP.value,
                         AISource.BOTH.value,
@@ -533,10 +547,12 @@ def main():
                         )
                 else:
                     console.print(
-                        "✅ [green]AI summary enabled with Gemini fallback.[/green]"
+                        "✅ [green]AI summary enabled with Gemini.[/green]"
                     )
             else:
-                console.print("✅ [green]AI summary enabled using ClickUp AI.[/green]")
+                console.print(
+                    f"✅ [green]AI summary enabled using {args.ai_source or AISource.CLAUDE.value}.[/green]"
+                )
         else:
             console.print("✅ [green]AI summary disabled.[/green]")
 
@@ -586,12 +602,32 @@ def main():
                 args.output_format, OutputFormat.MARKDOWN
             )
 
-    ai_source = AISource.BOTH
+    ai_source = AISource.CLAUDE
     if args.ai_source:
         try:
             ai_source = AISource(args.ai_source)
         except ValueError:
-            ai_source = AISource.BOTH
+            ai_source = AISource.CLAUDE
+
+    # The Claude source (and Both's fallback) shells out to the local `claude`
+    # CLI. Warn early if it isn't installed so the user understands why summaries
+    # may fall back to raw field content.
+    if (
+        args.ai_summary
+        and ai_source in (AISource.CLAUDE, AISource.BOTH)
+        and not claude_cli_available()
+    ):
+        console.print(
+            Panel(
+                "[yellow]⚠️  The 'claude' CLI was not found on PATH.[/yellow]\n"
+                "[dim]The Claude AI source needs Claude Code installed and signed in "
+                "(Max/Pro OAuth). Without it, summaries fall back to raw task content.[/dim]\n"
+                "[dim]Install: https://docs.claude.com/en/docs/claude-code  •  "
+                "or use [cyan]--ai-source Gemini[/cyan] with a Google API key.[/dim]",
+                title="Claude CLI Not Found",
+                style="yellow",
+            )
+        )
 
     ai_clickup_field_id = args.ai_clickup_field_id or CLICKUP_AI_SUMMARY_FIELD_ID
 

--- a/tests/test_claude_summary.py
+++ b/tests/test_claude_summary.py
@@ -53,6 +53,22 @@ class ClaudeSummaryTests(unittest.TestCase):
         self.assertIn("-p", cmd)
         self.assertIn("--model", cmd)
 
+    def test_subprocess_env_scrubs_api_key(self) -> None:
+        """The CLI runs without ANTHROPIC_API_KEY so it uses the OAuth subscription."""
+        with patch.dict(
+            "os.environ",
+            {"ANTHROPIC_API_KEY": "sk-should-be-removed", "PATH": "x"},
+            clear=False,
+        ), patch("ai_summary.shutil.which", return_value="/usr/bin/claude"), patch(
+            "ai_summary.subprocess.run",
+            return_value=_completed(stdout="ok"),
+        ) as mock_run:
+            get_claude_summary("Task", [("Status", "open")])
+
+        env = mock_run.call_args.kwargs["env"]
+        self.assertNotIn("ANTHROPIC_API_KEY", env)
+        self.assertNotIn("ANTHROPIC_AUTH_TOKEN", env)
+
     def test_empty_fields_short_circuits(self) -> None:
         with patch("ai_summary.subprocess.run") as mock_run:
             result = get_claude_summary("Task", [])

--- a/tests/test_claude_summary.py
+++ b/tests/test_claude_summary.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""
+Unit tests for the Claude CLI summary path in ai_summary.py.
+
+These mock subprocess.run / shutil.which so no real `claude` CLI call is made.
+They cover the happy path, the CLI-missing path, error/timeout handling, and the
+usage-limit "skip the rest of the run" behavior.
+"""
+
+import subprocess
+import unittest
+from unittest.mock import patch, MagicMock
+
+import ai_summary
+from ai_summary import get_claude_summary
+
+
+def _completed(returncode=0, stdout="", stderr=""):
+    proc = MagicMock(spec=subprocess.CompletedProcess)
+    proc.returncode = returncode
+    proc.stdout = stdout
+    proc.stderr = stderr
+    return proc
+
+
+class ClaudeSummaryTests(unittest.TestCase):
+    def setUp(self) -> None:
+        ai_summary._reset_claude_state()
+
+    def tearDown(self) -> None:
+        ai_summary._reset_claude_state()
+
+    def test_model_default_is_a_claude_id(self) -> None:
+        self.assertTrue(ai_summary.CLAUDE_SUMMARY_MODEL.startswith("claude-"))
+
+    def test_happy_path_returns_cleaned_summary(self) -> None:
+        with patch("ai_summary.shutil.which", return_value="/usr/bin/claude"), patch(
+            "ai_summary.subprocess.run",
+            return_value=_completed(stdout="I rebooted the printer\nand confirmed it works"),
+        ) as mock_run:
+            result = get_claude_summary(
+                "Fix printer", [("Status", "in progress")]
+            )
+
+        # Newlines collapsed to spaces, trailing period added.
+        self.assertEqual(result, "I rebooted the printer and confirmed it works.")
+        mock_run.assert_called_once()
+        # Prompt is passed over stdin, not as an argv element.
+        kwargs = mock_run.call_args.kwargs
+        self.assertIn("Status: in progress", kwargs["input"])
+        cmd = mock_run.call_args.args[0]
+        self.assertIn("-p", cmd)
+        self.assertIn("--model", cmd)
+
+    def test_empty_fields_short_circuits(self) -> None:
+        with patch("ai_summary.subprocess.run") as mock_run:
+            result = get_claude_summary("Task", [])
+        self.assertEqual(result, "No content available for summary.")
+        mock_run.assert_not_called()
+
+    def test_missing_cli_returns_none_without_running(self) -> None:
+        with patch("ai_summary.shutil.which", return_value=None), patch(
+            "ai_summary.subprocess.run"
+        ) as mock_run:
+            result = get_claude_summary("Task", [("Status", "open")])
+        self.assertIsNone(result)
+        mock_run.assert_not_called()
+
+    def test_nonzero_exit_returns_none(self) -> None:
+        with patch("ai_summary.shutil.which", return_value="/usr/bin/claude"), patch(
+            "ai_summary.subprocess.run",
+            return_value=_completed(returncode=1, stderr="some transient error"),
+        ):
+            result = get_claude_summary("Task", [("Status", "open")])
+        self.assertIsNone(result)
+        # A generic error should NOT disable Claude for the rest of the run.
+        self.assertTrue(ai_summary._claude_available)
+
+    def test_usage_limit_disables_claude_for_run(self) -> None:
+        with patch("ai_summary.shutil.which", return_value="/usr/bin/claude"), patch(
+            "ai_summary.subprocess.run",
+            return_value=_completed(returncode=1, stderr="Claude usage limit reached"),
+        ) as mock_run:
+            first = get_claude_summary("Task A", [("Status", "open")])
+            second = get_claude_summary("Task B", [("Status", "open")])
+
+        self.assertIsNone(first)
+        self.assertIsNone(second)
+        self.assertFalse(ai_summary._claude_available)
+        # Second call short-circuits before invoking the CLI again.
+        self.assertEqual(mock_run.call_count, 1)
+
+    def test_timeout_returns_none(self) -> None:
+        with patch("ai_summary.shutil.which", return_value="/usr/bin/claude"), patch(
+            "ai_summary.subprocess.run",
+            side_effect=subprocess.TimeoutExpired(cmd="claude", timeout=120),
+        ):
+            result = get_claude_summary("Task", [("Status", "open")])
+        self.assertIsNone(result)
+
+    def test_empty_stdout_returns_none(self) -> None:
+        with patch("ai_summary.shutil.which", return_value="/usr/bin/claude"), patch(
+            "ai_summary.subprocess.run",
+            return_value=_completed(stdout="   \n  "),
+        ):
+            result = get_claude_summary("Task", [("Status", "open")])
+        self.assertIsNone(result)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_extractor.py
+++ b/tests/test_extractor.py
@@ -144,6 +144,7 @@ class ClickUpTaskExtractorProcessTaskTests(unittest.TestCase):
 
     def test_process_task_with_ai_summary_enabled(self) -> None:
         self.config.enable_ai_summary = True
+        self.config.ai_source = AISource.GEMINI
         self.config.gemini_api_key = "secret"
         task = {"id": self.task_id, "name": "Printer outage"}
         list_item = {"name": "Support"}
@@ -205,6 +206,66 @@ class ClickUpTaskExtractorProcessTaskTests(unittest.TestCase):
         record = cast(TaskRecord, record)
         self.assertIn("Subject: Printer outage", record.Notes)
         mock_get_summary.assert_not_called()
+
+    def test_process_task_claude_source(self) -> None:
+        """Claude source summarizes via the claude CLI, not Gemini."""
+        self.config.enable_ai_summary = True
+        self.config.ai_source = AISource.CLAUDE
+        self.config.gemini_api_key = None
+
+        task = {"id": self.task_id, "name": "Printer outage"}
+        list_item = {"name": "Support"}
+
+        with patch(
+            "extractor.get_claude_summary", return_value="Claude summary text"
+        ) as mock_claude, patch("extractor.get_ai_summary") as mock_gemini:
+            record = self.extractor._process_task(task, [], list_item)
+
+        self.assertIsNotNone(record)
+        record = cast(TaskRecord, record)
+        self.assertEqual(record.Notes, "Claude summary text")
+        mock_claude.assert_called_once()
+        mock_gemini.assert_not_called()
+        called_task_name, fields_arg = mock_claude.call_args[0]
+        self.assertEqual(called_task_name, "Detailed Task")
+        self.assertEqual(fields_arg[0], ("Name", "Custom Task Name"))
+
+    def test_both_source_falls_back_to_claude(self) -> None:
+        """Both: with no ClickUp Summary field, fall back to Claude (not Gemini)."""
+        self.config.enable_ai_summary = True
+        self.config.ai_source = AISource.BOTH
+        self.config.ai_clickup_field_id = "missing-field"
+        self.config.gemini_api_key = None
+
+        task = {"id": self.task_id, "name": "Printer outage"}
+        list_item = {"name": "Support"}
+
+        with patch(
+            "extractor.get_claude_summary", return_value="Claude fallback summary"
+        ) as mock_claude, patch("extractor.get_ai_summary") as mock_gemini:
+            record = self.extractor._process_task(task, [], list_item)
+
+        self.assertIsNotNone(record)
+        record = cast(TaskRecord, record)
+        self.assertEqual(record.Notes, "Claude fallback summary")
+        mock_claude.assert_called_once()
+        mock_gemini.assert_not_called()
+
+    def test_claude_source_falls_back_to_base_notes_when_cli_unavailable(self) -> None:
+        """Claude returning None (CLI missing/limit) falls back to base notes."""
+        self.config.enable_ai_summary = True
+        self.config.ai_source = AISource.CLAUDE
+        self.config.gemini_api_key = None
+
+        task = {"id": self.task_id, "name": "Printer outage"}
+        list_item = {"name": "Support"}
+
+        with patch("extractor.get_claude_summary", return_value=None):
+            record = self.extractor._process_task(task, [], list_item)
+
+        self.assertIsNotNone(record)
+        record = cast(TaskRecord, record)
+        self.assertIn("Subject: Printer outage", record.Notes)
 
     def test_process_task_with_due_date(self) -> None:
         """Test that tasks with due dates use the due date as ETA."""

--- a/tests/test_interactive_ai_summary.py
+++ b/tests/test_interactive_ai_summary.py
@@ -14,7 +14,7 @@ import unittest
 from unittest.mock import patch, Mock, MagicMock, call
 from typing import Any
 
-from config import ClickUpConfig, OutputFormat, TaskRecord
+from config import AISource, ClickUpConfig, OutputFormat, TaskRecord
 from extractor import ClickUpTaskExtractor
 
 
@@ -111,6 +111,7 @@ class TestInteractiveAISummary(unittest.TestCase):
             output_format=OutputFormat.MARKDOWN,
             output_path="test_output.md",
             enable_ai_summary=True,
+            ai_source=AISource.GEMINI,
             gemini_api_key="test_gemini_key",
             interactive_selection=True,
         )
@@ -173,6 +174,7 @@ class TestInteractiveAISummary(unittest.TestCase):
             output_format=OutputFormat.MARKDOWN,
             output_path="test_output.md",
             enable_ai_summary=False,  # Not enabled via CLI
+            ai_source=AISource.GEMINI,  # opt-in path prompts for a Gemini key
             interactive_selection=True,
         )
 
@@ -263,6 +265,7 @@ class TestInteractiveAISummary(unittest.TestCase):
             output_format=OutputFormat.MARKDOWN,
             output_path="test_output.md",
             enable_ai_summary=True,
+            ai_source=AISource.GEMINI,
             gemini_api_key="test_gemini_key",
             interactive_selection=False,  # Non-interactive
         )
@@ -279,6 +282,52 @@ class TestInteractiveAISummary(unittest.TestCase):
             mock_ai_summary.call_count,
             3,
             "AI summary should be called for all tasks in non-interactive mode",
+        )
+
+    @patch("extractor.Progress")
+    @patch("extractor.console")
+    @patch("extractor.get_yes_no_input")
+    @patch("extractor.get_claude_summary")
+    def test_claude_opt_in_interactive_needs_no_key(
+        self, mock_claude, mock_get_yes_no, mock_console, mock_progress
+    ):
+        """Opting into Claude mid-run generates summaries without prompting for a key."""
+        mock_progress.return_value.__enter__ = Mock(
+            return_value=mock_progress.return_value
+        )
+        mock_progress.return_value.__exit__ = Mock(return_value=None)
+        mock_progress.return_value.add_task = Mock(return_value=1)
+        mock_progress.return_value.remove_task = Mock()
+        mock_progress.return_value.update = Mock()
+        mock_progress.return_value.advance = Mock()
+        mock_progress.return_value.stop = Mock()
+
+        # Select tasks 1 and 2, skip task 3, then opt in to AI summaries.
+        mock_get_yes_no.side_effect = [True, True, False, True]
+        mock_console.input = Mock(side_effect=AssertionError("should not prompt for a key"))
+        mock_claude.return_value = "Claude generated summary."
+
+        config = ClickUpConfig(
+            api_key="test_key",
+            workspace_name="Test Workspace",
+            space_name="Test Space",
+            output_format=OutputFormat.MARKDOWN,
+            output_path="test_output.md",
+            enable_ai_summary=False,  # opt in during the run
+            ai_source=AISource.CLAUDE,
+            interactive_selection=True,
+        )
+
+        api_client = DummyAPIClient(self.api_responses)
+        extractor = ClickUpTaskExtractor(config, api_client)
+
+        with patch.object(extractor, "export"):
+            extractor.run()
+
+        self.assertEqual(
+            mock_claude.call_count,
+            2,
+            "Claude summary should be generated for the 2 selected tasks",
         )
 
 


### PR DESCRIPTION
Fixes #144

## Summary
Gemini's free-tier rate limits frequently forced AI summaries to fall back to raw field content. This adds **Claude** as an AI summary source that shells out to the local `claude` CLI in headless print mode (`claude -p` over stdin), using the user's Claude Code **OAuth / Max subscription** — no API key, no Gemini quota — and makes it the default generative summarizer.

## Behavior
- New `AISource.CLAUDE`; `--ai-source Claude` and the interactive picker's default.
- `--ai-source Both` now resolves the ClickUp `Summary` field first, then falls back to **Claude** (was Gemini).
- Gemini stays fully available via `--ai-source Gemini`; a Gemini key is only loaded/prompted for that source.
- Model overridable via `CLAUDE_SUMMARY_MODEL` (default `claude-haiku-4-5-20251001`); per-call timeout via `CLAUDE_SUMMARY_TIMEOUT`.
- Graceful fallbacks: missing CLI, error, timeout, or usage-limit → raw field content (a usage-limit hit also skips further Claude calls for the run).

## Changes
- `config.py` — `AISource.CLAUDE`; default `ai_source` → `CLAUDE`.
- `ai_summary.py` — `get_claude_summary()` + `claude_cli_available()`; usage-limit/skip state.
- `extractor.py` — `_apply_ai_source` handles Claude and Both→Claude; `allow_gemini`→`allow_generative`; `_source_needs_gemini_key()` guards key loads; interactive mid-run opt-in needs no key for Claude/Both/ClickUp.
- `main.py` — `--ai-source Claude`; key load gated to Gemini-only; warns when the `claude` CLI is missing.
- Tests — new `tests/test_claude_summary.py` (subprocess mocked); Claude-path coverage in `test_extractor.py`; Gemini-path tests pinned to `AISource.GEMINI`; interactive Claude opt-in test.
- Docs — README, CHANGELOG, STATUS.md, CLAUDE.md, `.env.example`.

## Out of scope (follow-up)
`eta_calculator.py` still uses Gemini only; with Claude default + no Gemini key it cleanly uses the deterministic priority/status ETA. A separate issue will add Claude-powered ETA.

## Testing
- `296 passed` (full suite), including 12 new Claude-related tests.
- Verified the real `claude -p` invocation end-to-end through the venv Python (~7s, clean first-person summary, "(not provided)" fields ignored).

🤖 Generated with [Claude Code](https://claude.com/claude-code)