### PR TITLE
✨ Generate AI summaries concurrently (bounded thread pool)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -35,6 +35,9 @@ CLICKUP_API_KEY=
 # per-call timeout if desired:
 # CLAUDE_SUMMARY_MODEL=claude-haiku-4-5-20251001
 # CLAUDE_SUMMARY_TIMEOUT=120
+# Number of summaries generated concurrently (applies to Claude and Gemini).
+# Default 4; raise for faster large exports, lower to be gentler on rate limits.
+# AI_SUMMARY_CONCURRENCY=4
 
 # --- 1Password secret references (optional) ---------------------------------
 # op:// URIs pointing at the items that hold your API keys. When set, the tool

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -122,6 +122,7 @@ All retrieval is logged (DEBUG level); failures don't raise exceptions—they re
 - Filters by status (excludes by default per `ClickUpConfig.exclude_statuses`)
 - Filters by date range (`_fetch_and_process_tasks()`)
 - Interactive task selection (Rich panels with checkboxes)
+- **Deferred + concurrent AI summaries**: `_process_task` resolves only non-generative notes (ClickUp field / base notes) and stashes AI inputs in `TaskRecord._metadata`; generative summaries (Claude/Gemini) run afterward in one `_generate_summaries_concurrently()` pass (bounded `ThreadPoolExecutor`, `AI_SUMMARY_CONCURRENCY` env var, default 4). Covers both interactive (selected) and non-interactive (all) modes; preserves order; runs outside the live `Progress` display (`_progress_context` is cleared first).
 - `export_file()` context manager (creates parent dirs, handles I/O errors)
 - Markdown/HTML rendering (uses `get_export_fields()` for column order)
 

--- a/README.md
+++ b/README.md
@@ -365,6 +365,8 @@ Optional AI integration provides intelligent 1-2 sentence task summaries from se
 
 The **Claude** source needs no API key and is **not subject to Gemini's free-tier rate limits**, so it's the recommended default. It requires [Claude Code](https://docs.claude.com/en/docs/claude-code) installed and signed in. Override the model with `CLAUDE_SUMMARY_MODEL` (default `claude-haiku-4-5-20251001`) and the per-call timeout with `CLAUDE_SUMMARY_TIMEOUT` (seconds).
 
+Summaries are generated **concurrently** (bounded thread pool) after tasks are gathered, cutting wall-clock on large exports by ~3×. Tune the worker count with `AI_SUMMARY_CONCURRENCY` (default 4) — lower it to be gentler on rate limits, raise it for faster runs. Output order is preserved, and once a provider hits a usage/rate limit the remaining queued calls short-circuit.
+
 All sources gracefully fall back to the raw task content if the provider is unavailable, errors, or hits a usage limit.
 
 Enable AI summaries:

--- a/STATUS.md
+++ b/STATUS.md
@@ -6,9 +6,9 @@ Python CLI for extracting, processing, and exporting tasks from the ClickUp API.
 
 ## Current State — 2026-06-26
 
-**v1.05 shipped.** Beads (`bd`) is active as the task/memory layer beneath GitHub Issues.
+**v1.05 shipped.** Beads (`bd`) is active as the task/memory layer beneath GitHub Issues. Claude (Max OAuth) is the default AI summary source ([#144](https://github.com/J-MaFf/clickup_task_extractor/pull/145), merged).
 
-**In progress:** `feat/claude-ai-summary-source` ([#144](https://github.com/J-MaFf/clickup_task_extractor/issues/144)) — adds **Claude** as an AI summary source (local `claude` CLI / Max OAuth, no API key) and makes it the default generative summarizer, replacing rate-limited Gemini. Gemini stays available via `--ai-source Gemini`. All 296 tests pass.
+**In progress:** `feat/parallel-ai-summaries` ([#147](https://github.com/J-MaFf/clickup_task_extractor/issues/147)) — generate AI summaries concurrently (bounded `ThreadPoolExecutor`, `AI_SUMMARY_CONCURRENCY`, default 4) instead of serially, ~3× faster on large exports. Order preserved; usage-limit short-circuits queued calls. All 302 tests pass.
 
 ### Components
 
@@ -41,14 +41,16 @@ Python CLI for extracting, processing, and exporting tasks from the ClickUp API.
 | [#122](https://github.com/J-MaFf/clickup_task_extractor/issues/122) | Add GitHub Actions CI (pytest on push) | [#123](https://github.com/J-MaFf/clickup_task_extractor/pull/123) |
 | [#124](https://github.com/J-MaFf/clickup_task_extractor/issues/124) | Fix null type_config AttributeError | [#126](https://github.com/J-MaFf/clickup_task_extractor/pull/126) |
 | [#125](https://github.com/J-MaFf/clickup_task_extractor/issues/125) | Make API timeout configurable | [#127](https://github.com/J-MaFf/clickup_task_extractor/pull/127) |
+| [#144](https://github.com/J-MaFf/clickup_task_extractor/issues/144) | Add Claude (Max OAuth) AI summary source, make it default | [#145](https://github.com/J-MaFf/clickup_task_extractor/pull/145) |
 
 ### Open Issues
 
-- [#144](https://github.com/J-MaFf/clickup_task_extractor/issues/144) — Add Claude (Max OAuth) AI summary source, make it default (in review on `feat/claude-ai-summary-source`)
+- [#147](https://github.com/J-MaFf/clickup_task_extractor/issues/147) — Parallelize AI summary generation (in review on `feat/parallel-ai-summaries`)
+- [#146](https://github.com/J-MaFf/clickup_task_extractor/issues/146) — Add Claude as an ETA-calculation source in `eta_calculator.py`
 
 ## Natural Next Steps
 
-- Follow-up: let `eta_calculator.py` use the Claude CLI too (currently Gemini-only; falls back to deterministic priority/status ETA when no Gemini key)
+- #146: let `eta_calculator.py` use the Claude CLI too (currently Gemini-only; falls back to deterministic priority/status ETA when no Gemini key)
 - File new beads issues as work is identified (`bd create`)
 - Identify any bugs or improvements from v1.05 usage
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Added **Claude** as an AI summary source that shells out to the local `claude` CLI in headless print mode (`claude -p … --output-format text`), using your Claude Code **OAuth / Max subscription** — no API key required, and not subject to Gemini's free-tier rate limits. Select with `--ai-source Claude` (now the interactive default). The model is overridable via `CLAUDE_SUMMARY_MODEL` (default `claude-haiku-4-5-20251001`) and the per-call timeout via `CLAUDE_SUMMARY_TIMEOUT`. If a usage limit is hit, the CLI is missing, or a call errors, summaries fall back to raw field content (mirroring the Gemini failure path). ([#144](https://github.com/J-MaFf/clickup_task_extractor/issues/144))
+- **Concurrent AI summary generation.** Summaries are now generated in a single bounded-concurrency pass (`ThreadPoolExecutor`) after task processing instead of one-at-a-time, cutting wall-clock on large exports by ~3× (e.g. 6 Claude summaries in ~14s vs ~42s serial). Worker count is configurable via `AI_SUMMARY_CONCURRENCY` (default 4, clamped to the task count). Output order is preserved, and once a provider hits a usage/rate limit the remaining queued calls short-circuit. Applies to both interactive (selected tasks) and non-interactive (all tasks) modes. ([#147](https://github.com/J-MaFf/clickup_task_extractor/issues/147))
 
 ### Changed
 

--- a/extractor.py
+++ b/extractor.py
@@ -13,6 +13,7 @@ import os
 import sys
 import html
 import csv
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from datetime import datetime, timezone
 from typing import Callable, TypeAlias
 from contextlib import contextmanager
@@ -476,24 +477,13 @@ class ClickUpTaskExtractor:
                             name = task.get("name", "Unknown Task")
                             task_name = name[:30] + ("..." if len(name) > 30 else "")
 
-                            # Update per-list progress description with current task.
-                            # Show the AI indicator whenever a summary will be
-                            # generated in this pass (AI enabled, non-interactive).
-                            # The Claude source needs no API key, so don't gate on
-                            # gemini_api_key here.
-                            if (
-                                self.config.enable_ai_summary
-                                and not self.config.interactive_selection
-                            ):
-                                progress.update(
-                                    current_list_task,
-                                    description=f"📝 Processing: [bold]{list_item['name']}[/bold] - 🤖 AI: {task_name}",
-                                )
-                            else:
-                                progress.update(
-                                    current_list_task,
-                                    description=f"📝 Processing: [bold]{list_item['name']}[/bold] - {task_name}",
-                                )
+                            # Update per-list progress description with current
+                            # task. AI summaries are generated in a later
+                            # concurrent pass, so no AI indicator here.
+                            progress.update(
+                                current_list_task,
+                                description=f"📝 Processing: [bold]{list_item['name']}[/bold] - {task_name}",
+                            )
 
                             record = self._process_task(
                                 task, list_custom_fields, list_item
@@ -520,6 +510,11 @@ class ClickUpTaskExtractor:
                 if current_list_task is not None:
                     progress.remove_task(current_list_task)
                 progress.remove_task(overall_task)
+
+            # The live Progress display is now closed. Drop the reference so the
+            # rate-limit pause callback no-ops if invoked from the concurrent
+            # summary pass below (which runs outside any live display).
+            self._progress_context = None
 
             # Create beautiful summary table
             stats_table = Table(
@@ -564,100 +559,57 @@ class ClickUpTaskExtractor:
                 )
                 all_tasks = self.interactive_include(all_tasks)
 
-                # After task selection in interactive mode, handle AI summary generation
-                if all_tasks:
-                    # Check if we need to prompt for AI summary or if it's already enabled
-                    should_generate_ai = self.config.enable_ai_summary
-
-                    if not self.config.enable_ai_summary:
-                        # AI summary not enabled - ask the user
-                        console.print(
-                            Panel(
-                                f"[bold blue]🤖 AI Summary Available[/bold blue]\n"
-                                f"You have selected [bold cyan]{len(all_tasks)}[/bold cyan] task(s) for export.\n"
-                                f"AI summary can generate concise 1-2 sentence summaries using "
-                                f"[cyan]{self.config.ai_source.value}[/cyan].",
-                                title="AI Enhancement",
-                                style="blue",
-                            )
+                # After task selection, optionally enable AI summaries. The
+                # actual generation happens in the unified concurrent pass below
+                # (shared with non-interactive mode).
+                if all_tasks and not self.config.enable_ai_summary:
+                    console.print(
+                        Panel(
+                            f"[bold blue]🤖 AI Summary Available[/bold blue]\n"
+                            f"You have selected [bold cyan]{len(all_tasks)}[/bold cyan] task(s) for export.\n"
+                            f"AI summary can generate concise 1-2 sentence summaries using "
+                            f"[cyan]{self.config.ai_source.value}[/cyan].",
+                            title="AI Enhancement",
+                            style="blue",
                         )
-                        if get_yes_no_input(
-                            "Would you like to enable AI summaries for the selected tasks? (y/n): ",
-                            default_on_interrupt=False,
-                        ):
-                            if self.config.ai_source == AISource.GEMINI:
-                                # Gemini is the only source that needs an API key.
-                                gemini_key_loaded = False
-                                if self.load_gemini_key_func:
-                                    if self.load_gemini_key_func():
-                                        gemini_key_loaded = True
-                                        console.print(
-                                            "✅ [green]Gemini API key loaded from 1Password.[/green]"
-                                        )
+                    )
+                    if get_yes_no_input(
+                        "Would you like to enable AI summaries for the selected tasks? (y/n): ",
+                        default_on_interrupt=False,
+                    ):
+                        if self.config.ai_source == AISource.GEMINI:
+                            # Gemini is the only source that needs an API key.
+                            gemini_key_loaded = False
+                            if self.load_gemini_key_func:
+                                if self.load_gemini_key_func():
+                                    gemini_key_loaded = True
+                                    console.print(
+                                        "✅ [green]Gemini API key loaded from 1Password.[/green]"
+                                    )
 
-                                if not gemini_key_loaded:
-                                    gemini_key = console.input(
-                                        "[bold cyan]🔑 Enter Gemini API Key (or press Enter to skip): [/bold cyan]"
-                                    ).strip()
-                                    if gemini_key:
-                                        self.config.gemini_api_key = gemini_key
-                                        gemini_key_loaded = True
-                                        console.print(
-                                            "✅ [green]Manual Gemini API key entered.[/green]"
-                                        )
-                                    else:
-                                        console.print(
-                                            "ℹ️ [yellow]Proceeding without AI summary.[/yellow]"
-                                        )
+                            if not gemini_key_loaded:
+                                gemini_key = console.input(
+                                    "[bold cyan]🔑 Enter Gemini API Key (or press Enter to skip): [/bold cyan]"
+                                ).strip()
+                                if gemini_key:
+                                    self.config.gemini_api_key = gemini_key
+                                    gemini_key_loaded = True
+                                    console.print(
+                                        "✅ [green]Manual Gemini API key entered.[/green]"
+                                    )
+                                else:
+                                    console.print(
+                                        "ℹ️ [yellow]Proceeding without AI summary.[/yellow]"
+                                    )
 
-                                if gemini_key_loaded and self.config.gemini_api_key:
-                                    self.config.enable_ai_summary = True
-                                    should_generate_ai = True
-                            else:
-                                # Claude / Both / ClickUp need no API key.
+                            if gemini_key_loaded and self.config.gemini_api_key:
                                 self.config.enable_ai_summary = True
-                                should_generate_ai = True
                         else:
-                            console.print(
-                                "ℹ️ [yellow]Proceeding without AI summary.[/yellow]"
-                            )
-
-                    # Generate AI summaries for selected tasks if enabled
-                    if should_generate_ai:
+                            # Claude / Both / ClickUp need no API key.
+                            self.config.enable_ai_summary = True
+                    else:
                         console.print(
-                            Panel(
-                                f"[bold green]🧠 Generating AI summaries for {len(all_tasks)} selected tasks...[/bold green]",
-                                title="AI Processing",
-                                style="green",
-                            )
-                        )
-                        for i, task in enumerate(all_tasks, 1):
-                            console.print(
-                                f"  [dim]Processing task {i}/{len(all_tasks)}:[/dim] [bold]{task.Task}[/bold]"
-                            )
-                            metadata = getattr(task, "_metadata", {}) or {}
-                            task_name = metadata.get("task_name", task.Task)
-                            raw_fields = metadata.get("ai_fields") or []
-                            clickup_ai_summary = metadata.get("clickup_ai_summary")
-                            base_notes = metadata.get("base_notes", task.Notes)
-
-                            if isinstance(raw_fields, dict):
-                                ai_fields = list(raw_fields.items())
-                            else:
-                                ai_fields = list(raw_fields)
-
-                            if not ai_fields:
-                                ai_fields = [("Notes", task.Notes or "(not provided)")]
-
-                            task.Notes = self._apply_ai_source(
-                                task_name,
-                                ai_fields,
-                                base_notes,
-                                clickup_ai_summary,
-                                allow_generative=True,
-                            )
-                        console.print(
-                            "✅ [bold green]AI summaries generated for all selected tasks.[/bold green]"
+                            "ℹ️ [yellow]Proceeding without AI summary.[/yellow]"
                         )
 
             elif self.config.interactive_selection and not all_tasks:
@@ -668,6 +620,14 @@ class ClickUpTaskExtractor:
                         style="yellow",
                     )
                 )
+
+            # Generate AI summaries concurrently for the final task set. This
+            # single pass covers both interactive (selected tasks) and
+            # non-interactive (all tasks) modes; it no-ops when AI is disabled
+            # or the source makes no generative calls (ClickUp-only).
+            if all_tasks:
+                self._generate_summaries_concurrently(all_tasks)
+
             # Export
             self.export(all_tasks)
         except Exception as e:
@@ -855,12 +815,17 @@ class ClickUpTaskExtractor:
             base_notes = "\n".join(notes_parts)
             clickup_ai_summary = self._get_clickup_ai_summary(task_custom_fields)
 
+            # Resolve the non-generative notes synchronously (ClickUp Summary
+            # field or base notes). Generative summaries (Claude/Gemini) are
+            # deferred to a single concurrent pass after all tasks are processed
+            # (see _generate_summaries_concurrently) so they don't serialize the
+            # per-task fetch loop. The AI inputs are stashed in _metadata below.
             notes = self._apply_ai_source(
                 task_detail.get("name", ""),
                 ai_field_items,
                 base_notes,
                 clickup_ai_summary,
-                allow_generative=not self.config.interactive_selection,
+                allow_generative=False,
             )
 
             # Extract images (like original)
@@ -1062,6 +1027,103 @@ class ClickUpTaskExtractor:
         if allow_generative:
             return self._generate_claude_notes(task_name, ai_field_items, base_notes)
         return base_notes
+
+    def _summary_concurrency(self, task_count: int) -> int:
+        """Resolve the worker count for the concurrent summary pass.
+
+        Configurable via ``AI_SUMMARY_CONCURRENCY`` (default 4); clamped to
+        ``[1, task_count]`` so idle workers are never spawned. Kept conservative
+        by default to respect the Claude Max subscription / Gemini rate limits.
+        """
+        default = 4
+        try:
+            configured = int(os.environ.get("AI_SUMMARY_CONCURRENCY", default))
+        except ValueError:
+            configured = default
+        if configured < 1:
+            configured = 1
+        return max(1, min(configured, task_count))
+
+    def _summarize_one(self, task: TaskRecord) -> str:
+        """Generate AI notes for a single task from its stashed metadata."""
+        metadata = getattr(task, "_metadata", {}) or {}
+        task_name = metadata.get("task_name", task.Task)
+        raw_fields = metadata.get("ai_fields") or []
+        clickup_ai_summary = metadata.get("clickup_ai_summary")
+        base_notes = metadata.get("base_notes", task.Notes)
+
+        if isinstance(raw_fields, dict):
+            ai_fields = list(raw_fields.items())
+        else:
+            ai_fields = list(raw_fields)
+        if not ai_fields:
+            ai_fields = [("Notes", task.Notes or "(not provided)")]
+
+        return self._apply_ai_source(
+            task_name,
+            ai_fields,
+            base_notes,
+            clickup_ai_summary,
+            allow_generative=True,
+        )
+
+    def _generate_summaries_concurrently(self, tasks: TaskList) -> None:
+        """Generate AI summaries for ``tasks`` using a bounded thread pool.
+
+        Subprocess (Claude CLI) and HTTP (Gemini) calls release the GIL, so a
+        ThreadPoolExecutor parallelizes them effectively. Results are written
+        back in original order; progress is reported from the main thread via
+        ``as_completed`` (workers never touch the Rich console directly here).
+        No-ops when AI is disabled or the source is ClickUp-only (no external
+        call). Provider skip flags (``_claude_available`` / ``_api_available``)
+        cause queued calls to short-circuit once a usage/rate limit is hit.
+        """
+        if not self.config.enable_ai_summary or not tasks:
+            return
+        # ClickUp-only source was already resolved synchronously in _process_task.
+        if self.config.ai_source == AISource.CLICKUP:
+            return
+
+        total = len(tasks)
+        workers = self._summary_concurrency(total)
+        console.print(
+            Panel(
+                f"[bold green]🧠 Generating AI summaries for {total} task(s) "
+                f"using [cyan]{self.config.ai_source.value}[/cyan] "
+                f"({workers} concurrent)...[/bold green]",
+                title="AI Processing",
+                style="green",
+            )
+        )
+
+        results: list[str | None] = [None] * total
+        with ThreadPoolExecutor(max_workers=workers) as executor:
+            future_to_index = {
+                executor.submit(self._summarize_one, task): index
+                for index, task in enumerate(tasks)
+            }
+            completed = 0
+            for future in as_completed(future_to_index):
+                index = future_to_index[future]
+                try:
+                    results[index] = future.result()
+                except Exception as exc:  # keep going; leave existing Notes
+                    console.print(
+                        f"  [yellow]⚠️ Summary failed for '{tasks[index].Task}': "
+                        f"{str(exc)[:80]}[/yellow]"
+                    )
+                    results[index] = None
+                completed += 1
+                console.print(f"  [dim]{completed}/{total} summaries generated[/dim]")
+
+        # Write results back in original order. _apply_ai_source always returns a
+        # string (base notes on failure), so None only occurs on the unexpected
+        # exception above — leave those tasks' existing Notes untouched.
+        for index, task in enumerate(tasks):
+            if results[index] is not None:
+                task.Notes = results[index]
+
+        console.print("✅ [bold green]AI summaries complete.[/bold green]")
 
     def interactive_include(self, tasks: TaskList) -> TaskList:
         """

--- a/tests/test_extractor.py
+++ b/tests/test_extractor.py
@@ -143,6 +143,8 @@ class ClickUpTaskExtractorProcessTaskTests(unittest.TestCase):
         )
 
     def test_process_task_with_ai_summary_enabled(self) -> None:
+        # Generation is deferred: _process_task stashes AI inputs, and the
+        # concurrent pass (_generate_summaries_concurrently) calls the provider.
         self.config.enable_ai_summary = True
         self.config.ai_source = AISource.GEMINI
         self.config.gemini_api_key = "secret"
@@ -153,8 +155,10 @@ class ClickUpTaskExtractorProcessTaskTests(unittest.TestCase):
             "extractor.get_ai_summary", return_value="AI summary text"
         ) as mock_get_summary:
             record = self.extractor._process_task(task, [], list_item)
+            self.assertIsNotNone(record)
+            mock_get_summary.assert_not_called()  # deferred
+            self.extractor._generate_summaries_concurrently([record])
 
-        self.assertIsNotNone(record)
         self.assertIsInstance(record, TaskRecord)
         record = cast(TaskRecord, record)
         self.assertEqual(record.Notes, "AI summary text")
@@ -220,8 +224,10 @@ class ClickUpTaskExtractorProcessTaskTests(unittest.TestCase):
             "extractor.get_claude_summary", return_value="Claude summary text"
         ) as mock_claude, patch("extractor.get_ai_summary") as mock_gemini:
             record = self.extractor._process_task(task, [], list_item)
+            self.assertIsNotNone(record)
+            mock_claude.assert_not_called()  # deferred
+            self.extractor._generate_summaries_concurrently([record])
 
-        self.assertIsNotNone(record)
         record = cast(TaskRecord, record)
         self.assertEqual(record.Notes, "Claude summary text")
         mock_claude.assert_called_once()
@@ -244,8 +250,9 @@ class ClickUpTaskExtractorProcessTaskTests(unittest.TestCase):
             "extractor.get_claude_summary", return_value="Claude fallback summary"
         ) as mock_claude, patch("extractor.get_ai_summary") as mock_gemini:
             record = self.extractor._process_task(task, [], list_item)
+            self.assertIsNotNone(record)
+            self.extractor._generate_summaries_concurrently([record])
 
-        self.assertIsNotNone(record)
         record = cast(TaskRecord, record)
         self.assertEqual(record.Notes, "Claude fallback summary")
         mock_claude.assert_called_once()
@@ -262,8 +269,9 @@ class ClickUpTaskExtractorProcessTaskTests(unittest.TestCase):
 
         with patch("extractor.get_claude_summary", return_value=None):
             record = self.extractor._process_task(task, [], list_item)
+            self.assertIsNotNone(record)
+            self.extractor._generate_summaries_concurrently([record])
 
-        self.assertIsNotNone(record)
         record = cast(TaskRecord, record)
         self.assertIn("Subject: Printer outage", record.Notes)
 

--- a/tests/test_summary_concurrency.py
+++ b/tests/test_summary_concurrency.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""
+Unit tests for the concurrent AI-summary pass (_generate_summaries_concurrently).
+
+Covers: order/mapping preservation across workers, per-task call count,
+concurrency clamping, the ClickUp-only no-op, and that a mid-run provider
+usage-limit short-circuits remaining calls.
+"""
+
+import unittest
+from unittest.mock import patch
+
+import ai_summary
+from config import AISource, ClickUpConfig, OutputFormat, TaskRecord
+from extractor import ClickUpTaskExtractor
+
+
+class _DummyAPIClient:
+    def get(self, endpoint):  # pragma: no cover - not used by these tests
+        return {}
+
+
+def _make_record(name: str) -> TaskRecord:
+    """A TaskRecord with the _metadata the concurrent pass reads."""
+    rec = TaskRecord(
+        Task=name,
+        Company="Co",
+        Branch="",
+        Priority="Normal",
+        Status="Open",
+        ETA="",
+        Notes="base notes for " + name,
+        Extra="",
+    )
+    rec._metadata = {
+        "task_name": name,
+        "ai_fields": (("Name", name), ("Status", "Open")),
+        "base_notes": "base notes for " + name,
+        "clickup_ai_summary": None,
+    }
+    return rec
+
+
+def _config(source: AISource = AISource.CLAUDE) -> ClickUpConfig:
+    return ClickUpConfig(
+        api_key="k",
+        workspace_name="W",
+        space_name="S",
+        output_format=OutputFormat.MARKDOWN,
+        output_path="out.md",
+        enable_ai_summary=True,
+        ai_source=source,
+    )
+
+
+class SummaryConcurrencyTests(unittest.TestCase):
+    def setUp(self) -> None:
+        ai_summary._reset_claude_state()
+        ai_summary._reset_api_state()
+
+    def tearDown(self) -> None:
+        ai_summary._reset_claude_state()
+        ai_summary._reset_api_state()
+
+    def test_each_task_gets_its_own_summary_in_order(self) -> None:
+        """Results map back to the correct task regardless of completion order."""
+        extractor = ClickUpTaskExtractor(_config(AISource.CLAUDE), _DummyAPIClient())
+        records = [_make_record(f"Task {i}") for i in range(12)]
+
+        # Return a summary derived from the task name so we can verify mapping.
+        def fake_claude(task_name, fields, progress_pause_callback=None):
+            return f"summary::{task_name}"
+
+        with patch("extractor.get_claude_summary", side_effect=fake_claude) as mock_claude, patch(
+            "extractor.console"
+        ):
+            extractor._generate_summaries_concurrently(records)
+
+        self.assertEqual(mock_claude.call_count, 12)
+        for i, rec in enumerate(records):
+            self.assertEqual(rec.Notes, f"summary::Task {i}")
+
+    def test_concurrency_is_clamped_to_task_count(self) -> None:
+        extractor = ClickUpTaskExtractor(_config(), _DummyAPIClient())
+        with patch.dict("os.environ", {"AI_SUMMARY_CONCURRENCY": "8"}, clear=False):
+            self.assertEqual(extractor._summary_concurrency(3), 3)
+            self.assertEqual(extractor._summary_concurrency(20), 8)
+        with patch.dict("os.environ", {"AI_SUMMARY_CONCURRENCY": "0"}, clear=False):
+            self.assertEqual(extractor._summary_concurrency(5), 1)
+        with patch.dict("os.environ", {"AI_SUMMARY_CONCURRENCY": "notanint"}, clear=False):
+            self.assertEqual(extractor._summary_concurrency(10), 4)  # default
+
+    def test_clickup_source_makes_no_calls(self) -> None:
+        extractor = ClickUpTaskExtractor(_config(AISource.CLICKUP), _DummyAPIClient())
+        records = [_make_record("A"), _make_record("B")]
+        with patch("extractor.get_claude_summary") as mock_claude, patch(
+            "extractor.get_ai_summary"
+        ) as mock_gemini, patch("extractor.console"):
+            extractor._generate_summaries_concurrently(records)
+        mock_claude.assert_not_called()
+        mock_gemini.assert_not_called()
+
+    def test_disabled_ai_is_noop(self) -> None:
+        config = _config(AISource.CLAUDE)
+        config.enable_ai_summary = False
+        extractor = ClickUpTaskExtractor(config, _DummyAPIClient())
+        records = [_make_record("A")]
+        with patch("extractor.get_claude_summary") as mock_claude, patch("extractor.console"):
+            extractor._generate_summaries_concurrently(records)
+        mock_claude.assert_not_called()
+
+    def test_usage_limit_short_circuits_remaining_calls(self) -> None:
+        """Real get_claude_summary: a usage limit disables further CLI calls."""
+        extractor = ClickUpTaskExtractor(_config(AISource.CLAUDE), _DummyAPIClient())
+        records = [_make_record(f"T{i}") for i in range(6)]
+
+        def completed(returncode=0, stdout="", stderr=""):
+            class P:
+                pass
+
+            p = P()
+            p.returncode = returncode
+            p.stdout = stdout
+            p.stderr = stderr
+            return p
+
+        # First CLI call reports a usage limit -> flips the global skip flag;
+        # subsequent calls short-circuit before spawning a subprocess.
+        with patch("ai_summary.shutil.which", return_value="/usr/bin/claude"), patch(
+            "ai_summary.subprocess.run",
+            return_value=completed(returncode=1, stderr="Claude usage limit reached"),
+        ) as mock_run, patch("extractor.console"):
+            # Force serial execution so the flag is set before later items run.
+            with patch.dict("os.environ", {"AI_SUMMARY_CONCURRENCY": "1"}, clear=False):
+                extractor._generate_summaries_concurrently(records)
+
+        self.assertFalse(ai_summary._claude_available)
+        # Far fewer than 6 subprocesses ran (ideally 1); the rest short-circuited.
+        self.assertLess(mock_run.call_count, 6)
+        # All tasks keep their base notes (fallback).
+        for rec in records:
+            self.assertTrue(rec.Notes.startswith("base notes for "))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes #147

## Summary
AI summaries were generated one task at a time. The Claude CLI path is ~5–7s per task, so a non-interactive export of all open KMS/Kikkoman tasks (~36) took minutes. This generates summaries in a single **bounded-concurrency pass** after task processing.

## How it works
- `_process_task` now resolves only the **non-generative** notes synchronously (ClickUp `Summary` field or base notes) and stashes the AI inputs in `TaskRecord._metadata`.
- A new `_generate_summaries_concurrently()` runs the Claude/Gemini calls in a `ThreadPoolExecutor` (subprocess + HTTP release the GIL), then writes results back **in original order**.
- One unified pass covers both **interactive** (selected tasks) and **non-interactive** (all tasks) modes. It runs **outside** the live Rich `Progress` display (`_progress_context` is cleared first), and progress is reported from the main thread via `as_completed` — workers never touch the console directly.
- Concurrency is configurable via `AI_SUMMARY_CONCURRENCY` (default 4, clamped to the task count).
- Provider skip flags (`_claude_available` / `_api_available`) cause queued calls to short-circuit once a usage/rate limit is hit.

## Behavior preserved
- Output order unchanged.
- ClickUp-only source and AI-disabled both no-op (no threads, no external calls).
- Failures fall back to base notes, same as before.

## Testing
- `302 passed` (full suite), incl. new `tests/test_summary_concurrency.py`: order/mapping across workers, concurrency clamping, ClickUp/disabled no-op, and usage-limit short-circuit.
- Real end-to-end check: **6 Claude summaries in ~14s @4 workers** vs ~42s serial, order preserved, summaries accurate.

## Notes
- Default concurrency is deliberately conservative (4) to respect the Max subscription / Gemini rate limits; tune via `AI_SUMMARY_CONCURRENCY`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)