### PR TITLE
🚀 Release v1.06

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 A powerful, cross-platform Python application for extracting, processing, and exporting tasks from the ClickUp API with beautiful console interfaces and AI-powered summaries.
 
 ![Python](https://img.shields.io/badge/python-3.9%2B-blue.svg)
-![Version](https://img.shields.io/badge/version-1.05-green.svg)
+![Version](https://img.shields.io/badge/version-1.06-green.svg)
 ![Rich](https://img.shields.io/badge/rich-14.0%2B-green.svg)
 ![License](https://img.shields.io/badge/license-MIT-blue.svg)
 

--- a/STATUS.md
+++ b/STATUS.md
@@ -6,9 +6,9 @@ Python CLI for extracting, processing, and exporting tasks from the ClickUp API.
 
 ## Current State — 2026-06-26
 
-**v1.05 shipped.** Beads (`bd`) is active as the task/memory layer beneath GitHub Issues. AI summaries default to Claude (Max OAuth, [#145](https://github.com/J-MaFf/clickup_task_extractor/pull/145)); summaries + ETAs run concurrently ([#148](https://github.com/J-MaFf/clickup_task_extractor/pull/148)); ETAs can use Claude ([#149](https://github.com/J-MaFf/clickup_task_extractor/pull/149)); `main.py` auto-loads a project-local `.env` so configured workspace/space apply ([#151](https://github.com/J-MaFf/clickup_task_extractor/pull/151), Fixes [#150](https://github.com/J-MaFf/clickup_task_extractor/issues/150)) — all merged.
+**v1.06 in release.** Beads (`bd`) is active as the task/memory layer beneath GitHub Issues. Since v1.05: AI summaries default to Claude (Max OAuth, [#145](https://github.com/J-MaFf/clickup_task_extractor/pull/145)); summaries + ETAs run concurrently ([#148](https://github.com/J-MaFf/clickup_task_extractor/pull/148)); ETAs can use Claude ([#149](https://github.com/J-MaFf/clickup_task_extractor/pull/149)); `main.py` auto-loads a project-local `.env` so configured workspace/space apply ([#151](https://github.com/J-MaFf/clickup_task_extractor/pull/151)); `kfj_task_extractor.py` auto-loads `.env.kfj` secret-safely ([#153](https://github.com/J-MaFf/clickup_task_extractor/pull/153)) — all merged.
 
-**In progress:** `feat/load-dotenv-kfj` ([#152](https://github.com/J-MaFf/clickup_task_extractor/issues/152)) — `kfj_task_extractor.py` now auto-loads `.env.kfj` (same `_load_dotenv` pattern), but **secret-safe**: it skips `op://` values for `CLICKUP_API_KEY`/`GOOGLE_SHEETS_CREDENTIALS_JSON`, leaving them for `op run`/1Password. All 325 tests pass. Next: bump to **v1.06**.
+**In progress:** `release/v1.06` ([#154](https://github.com/J-MaFf/clickup_task_extractor/issues/154)) — version bump (`version.py` → 1.06, README badge, `CHANGELOG.md` `[1.06]`), then tag `v1.06` on `main`. All 325 tests pass.
 
 ### Components
 
@@ -46,14 +46,15 @@ Python CLI for extracting, processing, and exporting tasks from the ClickUp API.
 | [#147](https://github.com/J-MaFf/clickup_task_extractor/issues/147) | Concurrent AI summary generation | [#148](https://github.com/J-MaFf/clickup_task_extractor/pull/148) |
 | [#146](https://github.com/J-MaFf/clickup_task_extractor/issues/146) | Claude (Max OAuth) ETA estimation source | [#149](https://github.com/J-MaFf/clickup_task_extractor/pull/149) |
 | [#150](https://github.com/J-MaFf/clickup_task_extractor/issues/150) | Load `.env` at startup so configured workspace/space apply | [#151](https://github.com/J-MaFf/clickup_task_extractor/pull/151) |
+| [#152](https://github.com/J-MaFf/clickup_task_extractor/issues/152) | Auto-load `.env.kfj` in `kfj_task_extractor.py`, secret-safe | [#153](https://github.com/J-MaFf/clickup_task_extractor/pull/153) |
 
 ### Open Issues
 
-- [#152](https://github.com/J-MaFf/clickup_task_extractor/issues/152) — Auto-load `.env.kfj` in `kfj_task_extractor.py`, secret-safe (in review on `feat/load-dotenv-kfj`)
+- [#154](https://github.com/J-MaFf/clickup_task_extractor/issues/154) — Release v1.06 (in review on `release/v1.06`)
 
 ## Natural Next Steps
 
-- Version bump / release (`1.06`) once #152 lands — four+ user-facing features since 1.05 (Claude summaries, concurrency, Claude ETA, `.env`/`.env.kfj` auto-load)
+- After v1.06 tags: optionally build the PyInstaller exe into `dist/v1.06/` (gitignored; not required for source users)
 - Identify any bugs or improvements from real usage
 
 ## Prerequisites to Run

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.06] - 2026-06-26
+
 ### Added
 
 - Added **Claude** as an AI summary source that shells out to the local `claude` CLI in headless print mode (`claude -p … --output-format text`), using your Claude Code **OAuth / Max subscription** — no API key required, and not subject to Gemini's free-tier rate limits. Select with `--ai-source Claude` (now the interactive default). The model is overridable via `CLAUDE_SUMMARY_MODEL` (default `claude-haiku-4-5-20251001`) and the per-call timeout via `CLAUDE_SUMMARY_TIMEOUT`. If a usage limit is hit, the CLI is missing, or a call errors, summaries fall back to raw field content (mirroring the Gemini failure path). ([#144](https://github.com/J-MaFf/clickup_task_extractor/issues/144))

--- a/version.py
+++ b/version.py
@@ -1,6 +1,6 @@
 """Version information for ClickUp Task Extractor."""
 
-__version__ = "1.05"
+__version__ = "1.06"
 __author__ = "J-MaFf"
 __description__ = (
     "ClickUp Task Extractor - Extract, process, and export tasks from ClickUp API"
@@ -8,7 +8,7 @@ __description__ = (
 __url__ = "https://github.com/J-MaFf/clickup_task_extractor"
 
 # Release information
-RELEASE_DATE = "2026-06-23"
+RELEASE_DATE = "2026-06-26"
 PYTHON_REQUIRES = ">=3.9"
 
 # Feature flags for this version
@@ -16,6 +16,10 @@ FEATURES = {
     "rich_ui": True,
     "onepassword_integration": True,
     "ai_summary": True,
+    "claude_oauth_summary": True,
+    "concurrent_ai": True,
+    "ai_eta_estimation": True,
+    "dotenv_config": True,
     "interactive_selection": True,
     "html_export": True,
     "csv_export": True,


### PR DESCRIPTION
Fixes #154

Cuts the **v1.06** release capturing the user-facing features merged since v1.05.

## Changes
- `version.py` → `1.06` (`RELEASE_DATE = 2026-06-26`; new feature flags: `claude_oauth_summary`, `concurrent_ai`, `ai_eta_estimation`, `dotenv_config`)
- README version badge → 1.06
- `CHANGELOG.md`: rolled `[Unreleased]` into `[1.06] - 2026-06-26`
- `STATUS.md`: v1.06 in release; #150/#152 moved to Resolved; next steps refreshed

## Included since v1.05
- Claude (Max OAuth) AI summary source + new default (#145)
- Concurrent AI summary generation (#148)
- Claude (Max OAuth) ETA estimation (#149)
- Auto-load project-local `.env` for workspace/space (#151 / #150)
- Auto-load `.env.kfj`, secret-safe (#153 / #152)

## After merge
Tag `v1.06` on `main` (matches the existing `v1.0x` tag scheme). The PyInstaller exe (`dist/v1.06/`) is gitignored and optional — not required for source users.

## Testing
\`\`\`
.\.venv\Scripts\python.exe -m pytest tests/   # 325 passing
\`\`\`