### PR TITLE
feat: Add pytest-windows CI job on self-hosted runner

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -19,7 +19,8 @@ jobs:
       (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
       (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
     # ubuntu-latest: the action installs the Claude CLI here reliably (it cannot on
-    # windows-latest). Windows-specific test execution lives in windows-tests.yml.
+    # windows-latest). Windows-specific test execution lives in the pytest-windows
+    # job in tests.yml (self-hosted win-test runner).
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,6 +5,11 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: tests-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   pytest:
@@ -26,3 +31,55 @@ jobs:
 
       - name: Run tests
         run: pytest tests/ -v
+
+  pytest-windows:
+    name: pytest (windows)
+    # Self-hosted win-test runner (Windows Server 2025, Python 3.14 all-users +
+    # py launcher, pwsh default shell). The 1Password CLI is on the runner's
+    # PATH but carries no credentials; the suite mocks every op/SDK call.
+    #
+    # Fork-PR gate: this is a public repo, so PRs from forks must never execute
+    # on the self-hosted box. A skipped job still satisfies required status
+    # checks if this is ever added to the ruleset.
+    runs-on: [self-hosted, windows]
+    timeout-minutes: 30
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+    env:
+      PYTHONUTF8: "1"
+      # Blank out anything ambient on the shared runner so no ClickUp/1Password
+      # code path can see real configuration ("" reads as unset everywhere).
+      CLICKUP_API_KEY: ""
+      CLICKUP_API_SECRET_REFERENCE: ""
+      OP_ENVIRONMENT_ID: ""
+      OP_SERVICE_ACCOUNT_TOKEN: ""
+      GEMINI_API_KEY: ""
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Resolve Python
+        run: |
+          $PSNativeCommandUseErrorActionPreference = $true
+          $cand = @('py', 'python3', 'python') | Where-Object { Get-Command $_ -ErrorAction SilentlyContinue } | Select-Object -First 1
+          if (-not $cand) { throw 'No Python interpreter found (tried py, python3, python)' }
+          "PYBOOT=$cand" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
+          & $cand --version
+
+      - name: Install dependencies
+        run: |
+          $PSNativeCommandUseErrorActionPreference = $true
+          & $env:PYBOOT -m venv .venv
+          $venvPy = Join-Path $PWD '.venv\Scripts\python.exe'
+          "VENV_PY=$venvPy" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
+          # Mirror the ubuntu job: exclude the onepassword SDK (tests mock it).
+          # The venv is per-run (checkout's git clean wipes it), but the pip
+          # wheel cache in the runner user's profile persists, so installs are
+          # fast after the first run.
+          (Get-Content requirements.txt) | Where-Object { $_ -notmatch 'onepassword' } | Set-Content "$env:RUNNER_TEMP\requirements-ci.txt"
+          & $venvPy -m pip install -r "$env:RUNNER_TEMP\requirements-ci.txt"
+          & $venvPy -m pip install pytest
+
+      - name: Run tests
+        run: |
+          $PSNativeCommandUseErrorActionPreference = $true
+          & $env:VENV_PY -m pytest tests/ -v

--- a/STATUS.md
+++ b/STATUS.md
@@ -4,9 +4,9 @@
 
 Python CLI for extracting, processing, and exporting tasks from the ClickUp API. Supports Markdown, HTML, and CSV output, optional AI summaries (Claude via Max/Pro OAuth by default, or Google Gemini, or the ClickUp Summary field), 1Password-backed authentication, and a Rich console UI with interactive task selection and priority/ETA sorting.
 
-## Current State — 2026-06-26
+## Current State — 2026-07-06
 
-**v1.06 in release.** Beads (`bd`) is active as the task/memory layer beneath GitHub Issues. Since v1.05: AI summaries default to Claude (Max OAuth, [#145](https://github.com/J-MaFf/clickup_task_extractor/pull/145)); summaries + ETAs run concurrently ([#148](https://github.com/J-MaFf/clickup_task_extractor/pull/148)); ETAs can use Claude ([#149](https://github.com/J-MaFf/clickup_task_extractor/pull/149)); `main.py` auto-loads a project-local `.env` so configured workspace/space apply ([#151](https://github.com/J-MaFf/clickup_task_extractor/pull/151)); `kfj_task_extractor.py` auto-loads `.env.kfj` secret-safely ([#153](https://github.com/J-MaFf/clickup_task_extractor/pull/153)) — all merged.
+**v1.06 in release.** CI now runs the suite on two OSes: hosted Linux (Python 3.11) and the self-hosted `win-test` Windows runner (Python 3.14) ([#156](https://github.com/J-MaFf/clickup_task_extractor/issues/156)). Beads (`bd`) is active as the task/memory layer beneath GitHub Issues. Since v1.05: AI summaries default to Claude (Max OAuth, [#145](https://github.com/J-MaFf/clickup_task_extractor/pull/145)); summaries + ETAs run concurrently ([#148](https://github.com/J-MaFf/clickup_task_extractor/pull/148)); ETAs can use Claude ([#149](https://github.com/J-MaFf/clickup_task_extractor/pull/149)); `main.py` auto-loads a project-local `.env` so configured workspace/space apply ([#151](https://github.com/J-MaFf/clickup_task_extractor/pull/151)); `kfj_task_extractor.py` auto-loads `.env.kfj` secret-safely ([#153](https://github.com/J-MaFf/clickup_task_extractor/pull/153)) — all merged.
 
 **In progress:** `release/v1.06` ([#154](https://github.com/J-MaFf/clickup_task_extractor/issues/154)) — version bump (`version.py` → 1.06, README badge, `CHANGELOG.md` `[1.06]`), then tag `v1.06` on `main`. All 325 tests pass.
 

--- a/STATUS.md
+++ b/STATUS.md
@@ -30,6 +30,7 @@ Python CLI for extracting, processing, and exporting tasks from the ClickUp API.
 
 | Issue | Description | PR |
 |-------|-------------|-----|
+| [#156](https://github.com/J-MaFf/clickup_task_extractor/issues/156) | Run tests on the self-hosted Windows runner | [#157](https://github.com/J-MaFf/clickup_task_extractor/pull/157) |
 | [#90](https://github.com/J-MaFf/clickup_task_extractor/issues/90) | Sort tasks by priority then ETA | [#102](https://github.com/J-MaFf/clickup_task_extractor/pull/102) |
 | [#104](https://github.com/J-MaFf/clickup_task_extractor/issues/104) | KFJ standalone Google Sheets sync | [#104](https://github.com/J-MaFf/clickup_task_extractor/pull/104) |
 | [#105](https://github.com/J-MaFf/clickup_task_extractor/issues/105) | Disable Rich show_locals (secret leak) | [#117](https://github.com/J-MaFf/clickup_task_extractor/pull/117) |

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Windows CI on the self-hosted `win-test` runner.** `tests.yml` gains a `pytest-windows` job (`runs-on: [self-hosted, windows]`, Python 3.14) alongside the existing hosted-Linux job (Python 3.11), so the suite now runs on the OS the extractor is primarily used on — with an incidental oldest-Python/newest-Python matrix. The job is gated off fork PRs (public repo + self-hosted runner), blanks all ambient `CLICKUP_*`/`OP_*`/`GEMINI_*` env vars, and mirrors the Linux job's exclusion of the `onepassword` SDK (the suite mocks it). Four test-file `open()` calls gained explicit `encoding="utf-8"` so results don't depend on Windows' cp1252 default. ([#156](https://github.com/J-MaFf/clickup_task_extractor/issues/156))
+
 ## [1.06] - 2026-06-26
 
 ### Added

--- a/tests/test_extractor_edge_flows.py
+++ b/tests/test_extractor_edge_flows.py
@@ -34,7 +34,7 @@ class TestExportFile(unittest.TestCase):
                 f.write("test content")
 
             self.assertTrue(os.path.exists(test_path))
-            with open(test_path, "r") as f:
+            with open(test_path, "r", encoding="utf-8") as f:
                 self.assertEqual(f.read(), "test content")
 
     def test_export_file_handles_existing_directory(self):
@@ -232,7 +232,7 @@ class TestMultiFormatExport(unittest.TestCase):
             # File should be in output/ directory
             actual_path = Path("output") / "test.md"
             self.assertTrue(actual_path.exists())
-            with open(actual_path, "r") as f:
+            with open(actual_path, "r", encoding="utf-8") as f:
                 content = f.read()
                 self.assertIn("# Weekly Task List", content)
                 self.assertIn("Test Task", content)
@@ -270,7 +270,7 @@ class TestMultiFormatExport(unittest.TestCase):
             # File should be in output/ directory
             actual_path = Path("output") / "test.html"
             self.assertTrue(actual_path.exists())
-            with open(actual_path, "r") as f:
+            with open(actual_path, "r", encoding="utf-8") as f:
                 content = f.read()
                 self.assertIn("HTML Test", content)
                 self.assertIn("HTML Company", content)

--- a/tests/test_logger_config.py
+++ b/tests/test_logger_config.py
@@ -208,7 +208,7 @@ class TestSetupLogging(unittest.TestCase):
                 handler.flush()
 
             # Check file contains message
-            with open(log_file, 'r') as f:
+            with open(log_file, 'r', encoding='utf-8') as f:
                 content = f.read()
                 self.assertIn("Test message", content)
 


### PR DESCRIPTION
Fixes #156

## Changes

Adds a `pytest-windows` job to `tests.yml` on the self-hosted `win-test` runner (Windows Server 2025, Python 3.14.6, 1Password CLI on PATH with zero credentials), alongside the unchanged hosted-Linux job. The suite now runs on the OS the extractor is primarily used on, and the two jobs form an incidental matrix: oldest supported Python (3.11) on Linux, newest (3.14) on Windows.

**Job design:**
- **Fork-PR gate** — `if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository`. Public repo + self-hosted runner means fork PRs must never execute on the box; a skipped job still satisfies required status checks if this is ever added to the ruleset. (Repo-level "require approval for all outside collaborators" was also enabled as part of runner hardening.)
- **Credential hygiene** — all ambient `CLICKUP_*` / `OP_*` / `GEMINI_*` env vars are blanked at the job level; every consuming code path treats `""` as unset. The `onepassword` SDK is excluded from the install exactly like the Linux job (the suite mocks it), and `op` being on the runner's PATH is inert — the `op run` re-exec in `main.py` only fires under the `__main__` guard, never on import.
- **Toolchain** — per-run venv (checkout's `git clean` wipes it, but the pip wheel cache in the runner profile persists, so installs are fast after the first run); Python resolved `py` → `python3` → `python` per house convention; `$PSNativeCommandUseErrorActionPreference = $true` in every multi-command pwsh step so a mid-step pip failure can't be masked by a later command's exit code.
- `workflow_dispatch` trigger and a per-ref concurrency group added, matching the sibling repos.

**Windows-correctness fixes in tests** (the job also sets `PYTHONUTF8=1` as a belt-and-braces): four `open(..., "r")` calls read UTF-8-written files with the platform default encoding — cp1252 on Windows. Added explicit `encoding="utf-8"`: `tests/test_logger_config.py:211`, `tests/test_extractor_edge_flows.py:37,235,273`.

**Housekeeping:** fixed the stale `claude.yml` comment referencing a nonexistent `windows-tests.yml`; STATUS.md and docs/CHANGELOG.md updated per repo conventions.

## Testing

- Full suite locally on Linux with these changes: **325 passed** (mirrors the ubuntu job).
- The `pull_request` trigger runs both jobs from this branch — this PR's `pytest (windows)` check is the live validation on `win-test`.