### PR TITLE
🐛 Fail fast when the Claude CLI is not logged in

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -52,6 +52,9 @@ Python CLI for extracting, processing, and exporting tasks from the ClickUp API.
 ### Open Issues
 
 - [#154](https://github.com/J-MaFf/clickup_task_extractor/issues/154) — Release v1.06 (in review on `release/v1.06`)
+- [#159](https://github.com/J-MaFf/clickup_task_extractor/issues/159) — Claude CLI "Not logged in" repeats for every task; no fail-fast / pre-flight auth check (fix on `fix/claude-cli-auth-fail-fast`)
+- [#160](https://github.com/J-MaFf/clickup_task_extractor/issues/160) — AI passes report "N/N generated" + success even when every generation failed
+- [#161](https://github.com/J-MaFf/clickup_task_extractor/issues/161) — ClickUp Summary empty-field warning shown for the Claude AI source
 
 ## Natural Next Steps
 

--- a/ai_summary.py
+++ b/ai_summary.py
@@ -14,6 +14,7 @@ import os
 import shutil
 import subprocess
 import tempfile
+import threading
 import time
 from typing import Callable, Mapping, Sequence, TypeAlias
 
@@ -83,8 +84,12 @@ _last_error_message = ""
 # Global state for the Claude CLI path. Once a usage/rate limit is hit we stop
 # calling the CLI for the rest of the run (mirrors Gemini's _api_available),
 # since the Max subscription limit won't clear within a single extraction.
+# The lock makes the flag flip + one-time message atomic across the concurrent
+# summary/ETA workers (several may already be past the entry gate when the
+# first failure lands).
 _claude_available = True
 _claude_missing_warned = False
+_claude_state_lock = threading.Lock()
 
 # Google GenAI SDK imports (google.genai)
 try:
@@ -425,6 +430,21 @@ def claude_cli_available() -> bool:
     return shutil.which("claude") is not None
 
 
+def _subscription_env() -> dict[str, str]:
+    """Environment for `claude` subprocesses with the API-key vars scrubbed.
+
+    Forces OAuth/subscription auth (no-op when the vars are absent). Used by
+    both the generation calls and the auth-status probe so the probe reports
+    the same auth state the generation calls will actually run under — an
+    exported ANTHROPIC_API_KEY must not mask a logged-out OAuth state.
+    """
+    return {
+        k: v
+        for k, v in os.environ.items()
+        if k not in ("ANTHROPIC_API_KEY", "ANTHROPIC_AUTH_TOKEN")
+    }
+
+
 def claude_cli_authenticated(timeout: int = 15) -> bool | None:
     """
     Probe ``claude auth status`` for the CLI's login state.
@@ -451,6 +471,7 @@ def claude_cli_authenticated(timeout: int = 15) -> bool | None:
             errors="replace",
             timeout=timeout,
             cwd=tempfile.gettempdir(),
+            env=_subscription_env(),
         )
     except (subprocess.TimeoutExpired, OSError):
         return None
@@ -465,11 +486,22 @@ def claude_cli_authenticated(timeout: int = 15) -> bool | None:
     return None
 
 
+def _disable_claude_once() -> bool:
+    """Atomically disable the Claude CLI path; True only for the caller that
+    performed the flip. Several concurrent workers can be past run_claude_cli's
+    entry gate when the first terminal failure lands — only the first one
+    should print the run-wide message."""
+    global _claude_available
+    with _claude_state_lock:
+        was_available = _claude_available
+        _claude_available = False
+    return was_available
+
+
 def mark_claude_unavailable() -> None:
     """Disable the Claude CLI path for the rest of the run (e.g. after a
     failed pre-flight auth check). Mirrors the in-run flip in run_claude_cli."""
-    global _claude_available
-    _claude_available = False
+    _disable_claude_once()
 
 
 def claude_generation_available() -> bool:
@@ -554,11 +586,7 @@ def run_claude_cli(
     ]
 
     # Force OAuth/subscription auth: scrub API-key env vars (no-op when absent).
-    child_env = {
-        k: v
-        for k, v in os.environ.items()
-        if k not in ("ANTHROPIC_API_KEY", "ANTHROPIC_AUTH_TOKEN")
-    }
+    child_env = _subscription_env()
 
     try:
         proc = subprocess.run(
@@ -585,20 +613,20 @@ def run_claude_cli(
         error_str = (proc.stderr or proc.stdout or "").strip()
         _last_error_message = error_str[:150]
         if _is_auth_error(error_str):
-            _claude_available = False
-            _emit(
-                "[red]Claude CLI is not logged in - AI generation will be skipped "
-                "for the rest of this extraction.[/red]\n"
-                "[dim]Fix: run [cyan]claude auth login[/cyan] in a terminal (or "
-                "/login inside Claude Code), then re-run the extractor.[/dim]"
-            )
+            if _disable_claude_once():
+                _emit(
+                    "[red]Claude CLI is not logged in - AI generation will be skipped "
+                    "for the rest of this extraction.[/red]\n"
+                    "[dim]Fix: run [cyan]claude auth login[/cyan] in a terminal (or "
+                    "/login inside Claude Code), then re-run the extractor.[/dim]"
+                )
             return None, True
         if _is_rate_limit_error(error_str) or "usage limit" in error_str.lower():
-            _claude_available = False
-            _emit(
-                "[red]Claude usage limit reached - AI generation will be skipped for "
-                "the rest of this extraction.[/red]"
-            )
+            if _disable_claude_once():
+                _emit(
+                    "[red]Claude usage limit reached - AI generation will be skipped "
+                    "for the rest of this extraction.[/red]"
+                )
             return None, True
         _emit(f"❌ [red]Claude CLI error: {error_str[:100]}[/red]")
         return None, False

--- a/ai_summary.py
+++ b/ai_summary.py
@@ -9,6 +9,7 @@ Contains:
 - Progress bar functionality for wait times
 """
 
+import json
 import os
 import shutil
 import subprocess
@@ -154,6 +155,32 @@ def _is_rate_limit_error(error_str: str) -> bool:
         or "limit_exceeded" in error_lower
         or "requests per minute" in error_lower
         or "rpm" in error_lower
+    )
+
+
+def _is_auth_error(error_str: str) -> bool:
+    """
+    Detect if a Claude CLI error indicates an authentication failure.
+
+    Auth failures ("Not logged in · Please run /login", expired OAuth tokens)
+    are terminal for the whole run — unlike transient errors, they cannot
+    resolve until the user logs in again.
+
+    Args:
+        error_str: Error message string (CLI stderr/stdout)
+
+    Returns:
+        True if this is an authentication error, False otherwise
+    """
+    error_lower = error_str.lower()
+
+    return (
+        "not logged in" in error_lower
+        or "please run /login" in error_lower
+        or "please log in" in error_lower
+        or "oauth token has expired" in error_lower
+        or "authentication_error" in error_lower
+        or "invalid bearer token" in error_lower
     )
 
 
@@ -398,6 +425,58 @@ def claude_cli_available() -> bool:
     return shutil.which("claude") is not None
 
 
+def claude_cli_authenticated(timeout: int = 15) -> bool | None:
+    """
+    Probe ``claude auth status`` for the CLI's login state.
+
+    A cheap pre-flight check (no inference call) so callers can warn the user
+    before queueing a run's worth of doomed generation calls.
+
+    Returns:
+        True when the CLI reports it is logged in, False when it confidently
+        reports it is not, and None when the state is unknown (CLI missing,
+        older CLI without the subcommand, timeout, or unparseable output).
+        Callers should treat None as "proceed as usual".
+    """
+    claude_bin = shutil.which("claude")
+    if not claude_bin:
+        return None
+
+    try:
+        proc = subprocess.run(
+            [claude_bin, "auth", "status", "--json"],
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            timeout=timeout,
+            cwd=tempfile.gettempdir(),
+        )
+    except (subprocess.TimeoutExpired, OSError):
+        return None
+
+    try:
+        payload = json.loads(proc.stdout or "")
+    except ValueError:
+        return None
+
+    if isinstance(payload, dict) and isinstance(payload.get("loggedIn"), bool):
+        return payload["loggedIn"]
+    return None
+
+
+def mark_claude_unavailable() -> None:
+    """Disable the Claude CLI path for the rest of the run (e.g. after a
+    failed pre-flight auth check). Mirrors the in-run flip in run_claude_cli."""
+    global _claude_available
+    _claude_available = False
+
+
+def claude_generation_available() -> bool:
+    """Return True while the Claude CLI path is still usable this run."""
+    return _claude_available
+
+
 def _emit(message: str) -> None:
     """Print a message via Rich when available, else plain print."""
     if RICH_AVAILABLE and _console:
@@ -429,7 +508,9 @@ def run_claude_cli(
     API — is billed.
 
     Honors the global ``_claude_available`` skip flag and flips it off when a
-    usage/rate limit is detected, so callers in a loop stop issuing new calls.
+    usage/rate limit or an authentication failure ("Not logged in") is
+    detected, so callers in a loop stop issuing new calls — neither condition
+    can resolve within a single extraction.
 
     Args:
         prompt: The user prompt (sent on stdin).
@@ -439,10 +520,11 @@ def run_claude_cli(
         label: Short noun used in user-facing messages (e.g. "summary", "ETA").
 
     Returns:
-        ``(text, usage_limited)``. ``text`` is the stripped stdout, or ``None`` if
-        the CLI is missing, errored, timed out, was usage-limited, or produced no
-        output. ``usage_limited`` is True only when a usage/rate limit was hit
-        (or was already in effect), signalling callers to stop further calls.
+        ``(text, unavailable)``. ``text`` is the stripped stdout, or ``None`` if
+        the CLI is missing, errored, timed out, was usage-limited, not logged
+        in, or produced no output. ``unavailable`` is True only when a terminal
+        condition was hit (usage/rate limit or auth failure, or one was already
+        in effect), signalling callers to stop further calls.
     """
     global _claude_available, _claude_missing_warned, _last_error_message
 
@@ -502,6 +584,15 @@ def run_claude_cli(
     if proc.returncode != 0:
         error_str = (proc.stderr or proc.stdout or "").strip()
         _last_error_message = error_str[:150]
+        if _is_auth_error(error_str):
+            _claude_available = False
+            _emit(
+                "[red]Claude CLI is not logged in - AI generation will be skipped "
+                "for the rest of this extraction.[/red]\n"
+                "[dim]Fix: run [cyan]claude auth login[/cyan] in a terminal (or "
+                "/login inside Claude Code), then re-run the extractor.[/dim]"
+            )
+            return None, True
         if _is_rate_limit_error(error_str) or "usage limit" in error_str.lower():
             _claude_available = False
             _emit(

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Claude CLI login failures now fail fast instead of erroring on every task.** When the `claude` CLI is logged out, a run previously spawned a failing subprocess for every summary and every ETA (81 identical `Not logged in · Please run /login` errors on a 41-task export). Now: `main.py` pre-flights `claude auth status` when the AI source is Claude/Both and warns before extraction starts; the first in-run auth failure disables the Claude path for the rest of the run (mirroring the usage-limit behavior) with a one-time actionable message (`claude auth login`); and the concurrent summary/ETA passes skip entirely — with a single notice — when the Claude provider is already known to be unavailable. ([#159](https://github.com/J-MaFf/clickup_task_extractor/issues/159))
+
 ### Added
 
 - **Windows CI on the self-hosted `win-test` runner.** `tests.yml` gains a `pytest-windows` job (`runs-on: [self-hosted, windows]`, Python 3.14) alongside the existing hosted-Linux job (Python 3.11), so the suite now runs on the OS the extractor is primarily used on — with an incidental oldest-Python/newest-Python matrix. The job is gated off fork PRs (public repo + self-hosted runner), blanks all ambient `CLICKUP_*`/`OP_*`/`GEMINI_*` env vars, and mirrors the Linux job's exclusion of the `onepassword` SDK (the suite mocks it). Four test-file `open()` calls gained explicit `encoding="utf-8"` so results don't depend on Windows' cp1252 default. ([#156](https://github.com/J-MaFf/clickup_task_extractor/issues/156))

--- a/extractor.py
+++ b/extractor.py
@@ -54,7 +54,11 @@ from api_client import (
     AuthenticationError,
     ShardRoutingError,
 )
-from ai_summary import get_ai_summary, get_claude_summary
+from ai_summary import (
+    claude_generation_available,
+    get_ai_summary,
+    get_claude_summary,
+)
 from mappers import get_yes_no_input, get_choice_input, get_date_range, extract_images, LocationMapper
 from eta_calculator import calculate_eta
 
@@ -1089,6 +1093,15 @@ class ClickUpTaskExtractor:
         # ClickUp-only source was already resolved synchronously in _process_task.
         if self.config.ai_source == AISource.CLICKUP:
             return
+        # A Claude-only run can't generate anything once the CLI is unavailable
+        # (not logged in / usage-limited); Notes already hold the fallback from
+        # _process_task. (Both still runs — it consumes the ClickUp field.)
+        if self.config.ai_source == AISource.CLAUDE and not claude_generation_available():
+            console.print(
+                "[yellow]⊘ Skipping AI summaries - the Claude CLI is unavailable "
+                "(not logged in or usage-limited); using base task notes.[/yellow]"
+            )
+            return
 
         total = len(tasks)
         workers = self._summary_concurrency(total)
@@ -1155,6 +1168,18 @@ class ClickUpTaskExtractor:
         if not self.config.enable_ai_summary or not tasks:
             return
         if self.config.ai_source == AISource.CLICKUP:
+            return
+        # AI ETAs come from the Claude CLI for both the Claude and Both sources;
+        # when it's unavailable the deterministic baselines are already in place.
+        if (
+            self.config.ai_source in (AISource.CLAUDE, AISource.BOTH)
+            and not claude_generation_available()
+        ):
+            console.print(
+                "[yellow]⊘ Skipping AI ETA estimation - the Claude CLI is "
+                "unavailable (not logged in or usage-limited); keeping "
+                "deterministic baseline ETAs.[/yellow]"
+            )
             return
 
         candidates = [

--- a/main.py
+++ b/main.py
@@ -30,7 +30,11 @@ except ImportError:
     sys.exit(1)
 
 # Import project modules
-from ai_summary import claude_cli_available
+from ai_summary import (
+    claude_cli_authenticated,
+    claude_cli_available,
+    mark_claude_unavailable,
+)
 from auth import load_secret_with_fallback
 from config import (
     ClickUpConfig,
@@ -648,24 +652,37 @@ def main():
             ai_source = AISource.CLAUDE
 
     # The Claude source (and Both's fallback) shells out to the local `claude`
-    # CLI. Warn early if it isn't installed so the user understands why summaries
-    # may fall back to raw field content.
-    if (
-        args.ai_summary
-        and ai_source in (AISource.CLAUDE, AISource.BOTH)
-        and not claude_cli_available()
-    ):
-        console.print(
-            Panel(
-                "[yellow]⚠️  The 'claude' CLI was not found on PATH.[/yellow]\n"
-                "[dim]The Claude AI source needs Claude Code installed and signed in "
-                "(Max/Pro OAuth). Without it, summaries fall back to raw task content.[/dim]\n"
-                "[dim]Install: https://docs.claude.com/en/docs/claude-code  •  "
-                "or use [cyan]--ai-source Gemini[/cyan] with a Google API key.[/dim]",
-                title="Claude CLI Not Found",
-                style="yellow",
+    # CLI. Warn early if it isn't installed or isn't logged in, so the user
+    # learns before the extraction starts — not after a run's worth of failed
+    # generation calls (issue #159).
+    if args.ai_summary and ai_source in (AISource.CLAUDE, AISource.BOTH):
+        if not claude_cli_available():
+            console.print(
+                Panel(
+                    "[yellow]⚠️  The 'claude' CLI was not found on PATH.[/yellow]\n"
+                    "[dim]The Claude AI source needs Claude Code installed and signed in "
+                    "(Max/Pro OAuth). Without it, summaries fall back to raw task content.[/dim]\n"
+                    "[dim]Install: https://docs.claude.com/en/docs/claude-code  •  "
+                    "or use [cyan]--ai-source Gemini[/cyan] with a Google API key.[/dim]",
+                    title="Claude CLI Not Found",
+                    style="yellow",
+                )
             )
-        )
+        elif claude_cli_authenticated() is False:
+            # Confident "logged out" — skip the doomed generation calls up front.
+            # (None means "unknown" — e.g. an older CLI — and proceeds as usual.)
+            mark_claude_unavailable()
+            console.print(
+                Panel(
+                    "[yellow]⚠️  The 'claude' CLI is installed but not logged in.[/yellow]\n"
+                    "[dim]Claude summaries and ETA estimates will fall back to raw task "
+                    "content / deterministic ETAs for this run.[/dim]\n"
+                    "[dim]Fix: run [cyan]claude auth login[/cyan] in a terminal (or /login "
+                    "inside Claude Code), then re-run the extractor.[/dim]",
+                    title="Claude CLI Not Logged In",
+                    style="yellow",
+                )
+            )
 
     ai_clickup_field_id = args.ai_clickup_field_id or CLICKUP_AI_SUMMARY_FIELD_ID
 

--- a/tests/test_claude_summary.py
+++ b/tests/test_claude_summary.py
@@ -107,6 +107,23 @@ class ClaudeSummaryTests(unittest.TestCase):
         # Second call short-circuits before invoking the CLI again.
         self.assertEqual(mock_run.call_count, 1)
 
+    def test_auth_error_disables_claude_for_run(self) -> None:
+        """'Not logged in' is terminal: one failure disables the rest of the run."""
+        with patch("ai_summary.shutil.which", return_value="/usr/bin/claude"), patch(
+            "ai_summary.subprocess.run",
+            return_value=_completed(
+                returncode=1, stderr="Not logged in · Please run /login"
+            ),
+        ) as mock_run:
+            first = get_claude_summary("Task A", [("Status", "open")])
+            second = get_claude_summary("Task B", [("Status", "open")])
+
+        self.assertIsNone(first)
+        self.assertIsNone(second)
+        self.assertFalse(ai_summary._claude_available)
+        # Second call short-circuits before invoking the CLI again.
+        self.assertEqual(mock_run.call_count, 1)
+
     def test_timeout_returns_none(self) -> None:
         with patch("ai_summary.shutil.which", return_value="/usr/bin/claude"), patch(
             "ai_summary.subprocess.run",
@@ -122,6 +139,66 @@ class ClaudeSummaryTests(unittest.TestCase):
         ):
             result = get_claude_summary("Task", [("Status", "open")])
         self.assertIsNone(result)
+
+
+class ClaudeAuthProbeTests(unittest.TestCase):
+    """Tests for the `claude auth status` pre-flight probe and skip-flag setters."""
+
+    def setUp(self) -> None:
+        ai_summary._reset_claude_state()
+
+    def tearDown(self) -> None:
+        ai_summary._reset_claude_state()
+
+    def test_logged_in_returns_true(self) -> None:
+        with patch("ai_summary.shutil.which", return_value="/usr/bin/claude"), patch(
+            "ai_summary.subprocess.run",
+            return_value=_completed(stdout='{"loggedIn": true, "authMethod": "oauth"}'),
+        ) as mock_run:
+            self.assertTrue(ai_summary.claude_cli_authenticated())
+        cmd = mock_run.call_args.args[0]
+        self.assertEqual(cmd[1:3], ["auth", "status"])
+
+    def test_logged_out_returns_false(self) -> None:
+        with patch("ai_summary.shutil.which", return_value="/usr/bin/claude"), patch(
+            "ai_summary.subprocess.run",
+            return_value=_completed(
+                returncode=1,
+                stdout='{"loggedIn": false, "authMethod": "none"}',
+            ),
+        ):
+            self.assertFalse(ai_summary.claude_cli_authenticated())
+
+    def test_missing_cli_returns_none(self) -> None:
+        with patch("ai_summary.shutil.which", return_value=None), patch(
+            "ai_summary.subprocess.run"
+        ) as mock_run:
+            self.assertIsNone(ai_summary.claude_cli_authenticated())
+        mock_run.assert_not_called()
+
+    def test_unparseable_output_returns_none(self) -> None:
+        """Older CLIs without `auth status` print usage text, not JSON."""
+        with patch("ai_summary.shutil.which", return_value="/usr/bin/claude"), patch(
+            "ai_summary.subprocess.run",
+            return_value=_completed(returncode=1, stdout="Usage: claude [options]"),
+        ):
+            self.assertIsNone(ai_summary.claude_cli_authenticated())
+
+    def test_timeout_returns_none(self) -> None:
+        with patch("ai_summary.shutil.which", return_value="/usr/bin/claude"), patch(
+            "ai_summary.subprocess.run",
+            side_effect=subprocess.TimeoutExpired(cmd="claude", timeout=15),
+        ):
+            self.assertIsNone(ai_summary.claude_cli_authenticated())
+
+    def test_mark_claude_unavailable_short_circuits_cli(self) -> None:
+        self.assertTrue(ai_summary.claude_generation_available())
+        ai_summary.mark_claude_unavailable()
+        self.assertFalse(ai_summary.claude_generation_available())
+        with patch("ai_summary.subprocess.run") as mock_run:
+            result = get_claude_summary("Task", [("Status", "open")])
+        self.assertIsNone(result)
+        mock_run.assert_not_called()
 
 
 if __name__ == "__main__":

--- a/tests/test_claude_summary.py
+++ b/tests/test_claude_summary.py
@@ -107,6 +107,36 @@ class ClaudeSummaryTests(unittest.TestCase):
         # Second call short-circuits before invoking the CLI again.
         self.assertEqual(mock_run.call_count, 1)
 
+    def test_auth_error_message_emitted_once_across_threads(self) -> None:
+        """Workers already past the entry gate must not duplicate the run-wide
+        'not logged in' message — only the thread that flips the flag prints."""
+        import threading
+
+        barrier = threading.Barrier(2, timeout=5)
+
+        def fake_run(*args, **kwargs):
+            barrier.wait()  # both workers in-flight before either sees the error
+            return _completed(
+                returncode=1, stderr="Not logged in · Please run /login"
+            )
+
+        with patch("ai_summary.shutil.which", return_value="/usr/bin/claude"), patch(
+            "ai_summary.subprocess.run", side_effect=fake_run
+        ), patch("ai_summary._emit") as mock_emit:
+            threads = [
+                threading.Thread(
+                    target=get_claude_summary, args=(f"T{i}", [("Status", "open")])
+                )
+                for i in range(2)
+            ]
+            for t in threads:
+                t.start()
+            for t in threads:
+                t.join(timeout=10)
+
+        self.assertFalse(ai_summary._claude_available)
+        self.assertEqual(mock_emit.call_count, 1)
+
     def test_auth_error_disables_claude_for_run(self) -> None:
         """'Not logged in' is terminal: one failure disables the rest of the run."""
         with patch("ai_summary.shutil.which", return_value="/usr/bin/claude"), patch(
@@ -158,6 +188,26 @@ class ClaudeAuthProbeTests(unittest.TestCase):
             self.assertTrue(ai_summary.claude_cli_authenticated())
         cmd = mock_run.call_args.args[0]
         self.assertEqual(cmd[1:3], ["auth", "status"])
+
+    def test_probe_env_scrubs_api_key(self) -> None:
+        """The probe must report the OAuth state the generation calls will use —
+        an exported ANTHROPIC_API_KEY would otherwise mask a logged-out CLI
+        (`authMethod: api_key` reports loggedIn=true)."""
+        with patch.dict(
+            "os.environ",
+            {"ANTHROPIC_API_KEY": "sk-should-be-removed", "PATH": "x"},
+            clear=False,
+        ), patch("ai_summary.shutil.which", return_value="/usr/bin/claude"), patch(
+            "ai_summary.subprocess.run",
+            return_value=_completed(
+                returncode=1, stdout='{"loggedIn": false, "authMethod": "none"}'
+            ),
+        ) as mock_run:
+            self.assertFalse(ai_summary.claude_cli_authenticated())
+
+        env = mock_run.call_args.kwargs["env"]
+        self.assertNotIn("ANTHROPIC_API_KEY", env)
+        self.assertNotIn("ANTHROPIC_AUTH_TOKEN", env)
 
     def test_logged_out_returns_false(self) -> None:
         with patch("ai_summary.shutil.which", return_value="/usr/bin/claude"), patch(

--- a/tests/test_summary_concurrency.py
+++ b/tests/test_summary_concurrency.py
@@ -162,6 +162,59 @@ class SummaryConcurrencyTests(unittest.TestCase):
             self.assertTrue(rec.Notes.startswith("base notes for "))
 
 
+class ClaudeUnavailableSkipTests(unittest.TestCase):
+    """When the Claude CLI is known-unavailable (e.g. failed pre-flight auth
+    check), the Claude-dependent passes skip instead of queueing doomed work."""
+
+    def setUp(self) -> None:
+        ai_summary._reset_claude_state()
+        ai_summary._reset_api_state()
+
+    def tearDown(self) -> None:
+        ai_summary._reset_claude_state()
+        ai_summary._reset_api_state()
+
+    def test_summary_pass_skipped_for_claude_source(self) -> None:
+        extractor = ClickUpTaskExtractor(_config(AISource.CLAUDE), _DummyAPIClient())
+        records = [_make_record("A"), _make_record("B")]
+        ai_summary.mark_claude_unavailable()
+        with patch("extractor.get_claude_summary") as mock_claude, patch(
+            "extractor.console"
+        ):
+            extractor._generate_summaries_concurrently(records)
+        mock_claude.assert_not_called()
+        for rec in records:
+            self.assertTrue(rec.Notes.startswith("base notes for "))
+
+    def test_summary_pass_still_runs_for_both_source(self) -> None:
+        """Both consumes the ClickUp Summary field, so the pass must still run."""
+        extractor = ClickUpTaskExtractor(_config(AISource.BOTH), _DummyAPIClient())
+        record = _make_record("A")
+        record._metadata["clickup_ai_summary"] = "Summary from ClickUp field"
+        ai_summary.mark_claude_unavailable()
+        with patch("extractor.console"):
+            extractor._generate_summaries_concurrently([record])
+        self.assertEqual(record.Notes, "Summary from ClickUp field")
+
+    def test_eta_pass_skipped_for_claude_source(self) -> None:
+        extractor = ClickUpTaskExtractor(_config(AISource.CLAUDE), _DummyAPIClient())
+        tasks = [_make_eta_record("A")]
+        ai_summary.mark_claude_unavailable()
+        with patch("extractor.calculate_eta") as mock_eta, patch("extractor.console"):
+            extractor._generate_etas_concurrently(tasks)
+        mock_eta.assert_not_called()
+        self.assertEqual(tasks[0].ETA, "01/01/2026")  # baseline kept
+
+    def test_eta_pass_skipped_for_both_source(self) -> None:
+        """AI ETAs are Claude-only even for Both, so it skips too."""
+        extractor = ClickUpTaskExtractor(_config(AISource.BOTH), _DummyAPIClient())
+        tasks = [_make_eta_record("A")]
+        ai_summary.mark_claude_unavailable()
+        with patch("extractor.calculate_eta") as mock_eta, patch("extractor.console"):
+            extractor._generate_etas_concurrently(tasks)
+        mock_eta.assert_not_called()
+
+
 class ETAConcurrencyTests(unittest.TestCase):
     def setUp(self) -> None:
         ai_summary._reset_claude_state()


### PR DESCRIPTION
Fixes #159

## Problem

With the `claude` CLI logged out, a 41-task export printed `❌ Claude CLI error: Not logged in · Please run /login` **81 times** (41 summaries + 40 ETAs) — every task spawned a doomed subprocess because `run_claude_cli()` only treats usage/rate limits as terminal, and the only pre-flight check was a PATH lookup.

## Changes

- **`ai_summary.py`**
  - New `_is_auth_error()`: classifies "Not logged in / Please run /login / OAuth token has expired / …" as an authentication failure.
  - `run_claude_cli()` now disables the Claude path for the rest of the run on the **first** auth failure (same mechanism as usage limits) and prints one actionable message pointing at `claude auth login`.
  - New `claude_cli_authenticated()`: cheap pre-flight probe via `claude auth status --json` (no inference call). Returns `True`/`False`, or `None` for unknown (missing CLI, older CLI without the subcommand, timeout, unparseable output) — unknown never blocks.
  - New `mark_claude_unavailable()` / `claude_generation_available()` accessors.
- **`main.py`** — when AI source is Claude/Both: if the CLI is on PATH but confidently logged out, warn **before extraction starts** and disable the Claude path for the run.
- **`extractor.py`** — the concurrent summary pass (Claude source) and ETA pass (Claude/Both sources) skip with a single notice when Claude is already unavailable, instead of queueing a run's worth of failing calls. `Both` still runs the summary pass (it consumes the ClickUp Summary field).

## Testing

- `pytest tests/ -q` → **336 passed** (11 new tests: auth-error terminality, auth-probe matrix, pass-skip guards including the Both-still-runs-summaries case).
- Verified end-to-end against this machine's real logged-out CLI (v2.1.202): `claude_cli_authenticated()` → `False`; reproduction of the extractor's exact CLI invocation returns exit 1 with the observed error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)