### PR TITLE
📚 Reconcile beads memory guidance with scoped memory rule

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -65,7 +65,7 @@ bd close <id>         # Complete work
 
 - Use `bd` for ALL task tracking — do NOT use TodoWrite, TaskCreate, or markdown TODO lists
 - Run `bd prime` for detailed command reference and session close protocol
-- Use `bd remember` for persistent knowledge — do NOT use MEMORY.md files
+- Use `bd remember` for persistent, repo-scoped knowledge that travels with the repo via Dolt sync — this scoped rule supersedes any blanket ban on file-based memory emitted at runtime by `bd prime`/bd hooks; the assistant's own file-based memory (per-project MEMORY.md) still covers user- or machine-level context, and neither system replaces the other
 
 **Architecture in one line:** issues live in a local Dolt DB; sync uses `refs/dolt/data` on your git remote; `.beads/issues.jsonl` is a passive export. See https://github.com/gastownhall/beads/blob/main/docs/SYNC_CONCEPTS.md for details and anti-patterns.
 
@@ -123,7 +123,7 @@ bd prime                # Refresh Beads context
 
 - Use `bd` for all task tracking; do not create markdown TODO lists.
 - Run `bd prime` when Beads context is missing or stale. Codex 0.129.0+ can load Beads context automatically through native hooks; use `/hooks` to inspect or toggle them.
-- Keep persistent project memory in Beads via `bd remember`; do not create ad hoc memory files.
+- Use `bd remember` for persistent, repo-scoped knowledge that travels with the repo via Dolt sync — this scoped rule supersedes any blanket ban on file-based memory emitted at runtime by `bd prime`/bd hooks; the assistant's own file-based memory (per-project MEMORY.md) still covers user- or machine-level context, and neither system replaces the other.
 
 **Architecture in one line:** issues live in a local Dolt DB; sync uses `refs/dolt/data` on your git remote; `.beads/issues.jsonl` is a passive export. See https://github.com/gastownhall/beads/blob/main/docs/SYNC_CONCEPTS.md for details and anti-patterns.
 <!-- END BEADS CODEX SETUP -->

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -311,7 +311,7 @@ bd close <id>         # Complete work
 
 - Use `bd` for ALL task tracking — do NOT use TodoWrite, TaskCreate, or markdown TODO lists
 - Run `bd prime` for detailed command reference and session close protocol
-- Use `bd remember` for persistent knowledge — do NOT use MEMORY.md files
+- Use `bd remember` for persistent, repo-scoped knowledge that travels with the repo via Dolt sync — this scoped rule supersedes any blanket ban on file-based memory emitted at runtime by `bd prime`/bd hooks; the assistant's own file-based memory (per-project MEMORY.md) still covers user- or machine-level context, and neither system replaces the other
 
 **Architecture in one line:** issues live in a local Dolt DB; sync uses `refs/dolt/data` on your git remote; `.beads/issues.jsonl` is a passive export. See https://github.com/gastownhall/beads/blob/main/docs/SYNC_CONCEPTS.md for details and anti-patterns.
 


### PR DESCRIPTION
Fixes #177

## Changes
Replaced the blanket "do NOT use MEMORY.md" / "ad hoc memory files" lines in the auto-generated beads blocks with a single, identical scoped-rule sentence in all three spots:
- `CLAUDE.md` — BEADS INTEGRATION block
- `AGENTS.md` — BEADS INTEGRATION block
- `AGENTS.md` — BEADS CODEX SETUP block

The reconciled wording states: `bd remember` is for repo-scoped knowledge that travels with the repo via Dolt sync; the assistant's own file-based memory (per-project MEMORY.md) covers user/machine-level context; neither system replaces the other; and this scoped rule supersedes any blanket "do not use MEMORY.md" wording emitted at runtime by `bd prime` / bd hooks.

Only those three lines changed — no reformatting, no other wording changes, BEGIN/END markers and hash comments untouched.

## Intentional stale-hash note
This edit modifies content inside the machine-generated `<!-- BEGIN BEADS INTEGRATION v:1 profile:minimal hash:970c3bf2 -->` block, so `bd setup claude --check` will now report the block as **stale** (hash mismatch). This is expected and intentional — do **not** run `bd setup claude` or `bd setup codex` to "fix" it, as that would revert this reconciliation. Neither command was run during this change.

## Testing
- `grep -c "do NOT use MEMORY.md" CLAUDE.md` → 0
- `grep -c "do NOT use MEMORY.md" AGENTS.md` → 0
- `grep -c "ad hoc memory files" AGENTS.md` → 0
- `git diff` confirms exactly 3 changed lines across the 2 files
- Commit is signed (`git log --show-signature` shows a good ED25519 signature)

Merge left for human approval per repo workflow.